### PR TITLE
For pull_requests, use the original commit SHA for details.

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -16,6 +16,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
+var execSync = require('child_process').execSync;
 const fs = require('fs');
 const request = require('request');
 const coveralls = require('coveralls');
@@ -41,6 +42,13 @@ function run() {
                 const pr = JSON.parse(event).number;
                 process.env.CI_PULL_REQUEST = pr;
                 jobId = `${sha}-PR-${pr}`;
+                try {
+                    execSync('git rev-parse --verify ' + process.env.COVERALLS_GIT_COMMIT + "^2");
+                    process.env.COVERALLS_GIT_COMMIT += "^2";
+                }
+                catch (error) {
+                    core.warning("Can't find the PR head " + process.env.COVERALLS_GIT_COMMIT + "^2 so falling back to " + process.env.COVERALLS_GIT_COMMIT + ".  Maybe increase fetch-depth?  Error: " + error.message);
+                }
             }
             else {
                 jobId = sha;

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,4 +1,5 @@
 import * as core from '@actions/core';
+var execSync = require('child_process').execSync;
 
 const fs = require('fs');
 const request = require('request');
@@ -40,6 +41,12 @@ export async function run() {
       const pr = JSON.parse(event).number;
       process.env.CI_PULL_REQUEST = pr;
       jobId = `${sha}-PR-${pr}`;
+      try {
+        execSync('git rev-parse --verify ' + process.env.COVERALLS_GIT_COMMIT + "^2");
+        process.env.COVERALLS_GIT_COMMIT += "^2";
+      } catch (error) {
+        core.warning("Can't find the PR head " + process.env.COVERALLS_GIT_COMMIT + "^2 so falling back to " + process.env.COVERALLS_GIT_COMMIT + ".  Maybe increase fetch-depth?  Error: " + error.message);
+      }
     } else {
       jobId = sha;
     }

--- a/src/run.ts
+++ b/src/run.ts
@@ -41,11 +41,13 @@ export async function run() {
       const pr = JSON.parse(event).number;
       process.env.CI_PULL_REQUEST = pr;
       jobId = `${sha}-PR-${pr}`;
-      try {
-        execSync('git rev-parse --verify ' + process.env.COVERALLS_GIT_COMMIT + "^2");
-        process.env.COVERALLS_GIT_COMMIT += "^2";
-      } catch (error) {
-        core.warning("Can't find the PR head " + process.env.COVERALLS_GIT_COMMIT + "^2 so falling back to " + process.env.COVERALLS_GIT_COMMIT + ".  Maybe increase fetch-depth?  Error: " + error.message);
+      if(core.getInput('parallel-finished') != '') {
+        try {
+          execSync('git rev-parse --verify ' + process.env.COVERALLS_GIT_COMMIT + "^2");
+          process.env.COVERALLS_GIT_COMMIT += "^2";
+        } catch (error) {
+          core.warning("Can't find the PR head " + process.env.COVERALLS_GIT_COMMIT + "^2 so falling back to " + process.env.COVERALLS_GIT_COMMIT + ".  Maybe increase fetch-depth?  Error: " + error.message);
+        }
       }
     } else {
       jobId = sha;


### PR DESCRIPTION
When a PR is made, github runs CI not on the head of the PR but on the
head of the PR merged with the head of the branch on to which the PR
will merge.  Coveralls should use the details from the head of the PR
branch, not those of the merge that github does.