### PR TITLE
Set COVERALLS_SERVICE_NUMBER so that parallel builds are aggregated.

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -46,6 +46,7 @@ function run() {
                 jobId = sha;
             }
             process.env.COVERALLS_SERVICE_JOB_ID = jobId;
+            process.env.COVERALLS_SERVICE_NUMBER = jobId;
             const endpoint = core.getInput('coveralls-endpoint');
             if (endpoint != '') {
                 process.env.COVERALLS_ENDPOINT = endpoint;

--- a/src/run.ts
+++ b/src/run.ts
@@ -45,6 +45,7 @@ export async function run() {
     }
 
     process.env.COVERALLS_SERVICE_JOB_ID = jobId
+    process.env.COVERALLS_SERVICE_NUMBER = jobId
 
     const endpoint = core.getInput('coveralls-endpoint');
     if (endpoint != '') {


### PR DESCRIPTION
As the documentation of the https://github.com/nickmerwin/node-coveralls state coveralls aggregates the coverage of parallel builds using `COVERALLS_SERVICE_NUMBER`.  This fixed the issue for me on parallel builds.
Fixes #13 Fixes #18 and maybe related to #33 