### PR TITLE
Support for raw coverage file

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,18 @@ author: 'Nick Merwin (Coveralls, Inc.)'
 inputs:
   github-token:
     required: true
-  path-to-lcov:
-    description: 'Path to lcov file'
+  path-to-file:
+    description: 'Path to coverage file'
     required: true
     default: './coverage/lcov.info'
+  path-to-lcov:
+    description: 'Path to lcov file (Deprecated)'
+    required: true
+    default: './coverage/lcov.info'
+  coverage-format:
+    description: ' Format of coverage file. Acccepted values are `lcov` and `raw`. Defaults to `lcov`'
+    required: true
+    default: 'lcov'
   flag-name:
     description: 'Job flag name, e.g. "Unit", "Functional", or "Integration". Will be shown in the Coveralls UI.'
     required: false

--- a/lib/run.js
+++ b/lib/run.js
@@ -1,9 +1,10 @@
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -78,28 +79,92 @@ function run() {
                 return 0;
             }
             process.env.COVERALLS_PARALLEL = process.env.COVERALLS_PARALLEL || core.getInput('parallel');
+            const defaultPath = './coverage/lcov.info';
+            const defaultType = 'lcov';
+            const pathToFile = core.getInput('path-to-file');
             const pathToLcov = core.getInput('path-to-lcov');
-            if (pathToLcov == '') {
-                throw new Error("No Lcov path specified.");
+            const formatInput = core.getInput('coverage-format');
+            const filetype = formatInput !== defaultType ? formatInput : defaultType;
+            if (filetype !== defaultType && filetype !== 'raw') {
+                throw new Error(`Unsupported file format: ${filetype}`);
             }
-            console.log(`Using lcov file: ${pathToLcov}`);
+            // for compatibility with the name path-to-lcov - go through these steps
+            // 1. use 'path-to-file' if its not the default path
+            // 2. use 'path-to-lcov' if its not the default
+            // 3. use 'path-to-file' (which will be the default at this point in time - but i made it more explicit)
+            const pathToUse = pathToFile !== defaultPath ? pathToFile : ((pathToLcov !== defaultPath) ? pathToLcov : pathToFile);
+            if (pathToUse == '') {
+                throw new Error("No file path specified.");
+            }
+            console.log(`Using ${filetype} file: ${pathToUse}`);
             let file;
             try {
-                file = fs_1.default.readFileSync(pathToLcov, 'utf8');
+                file = fs_1.default.readFileSync(pathToUse, 'utf8');
             }
             catch (err) {
-                throw new Error("Lcov file not found.");
+                throw new Error(`${filetype} file not found.`);
             }
             const basePath = core.getInput('base-path');
             const adjustedFile = basePath ? lcov_processor_1.adjustLcovBasePath(file, basePath) : file;
-            coveralls.handleInput(adjustedFile, (err, body) => {
-                if (err) {
-                    core.setFailed(err);
-                }
-                else {
-                    core.setOutput('coveralls-api-result', body);
-                }
-            });
+            if (filetype === 'raw') {
+                coveralls.getOptions((err, options) => {
+                    if (err) {
+                        core.setFailed(err);
+                    }
+                    const postJson = JSON.parse(adjustedFile);
+                    if (options.flag_name) {
+                        postJson.flag_name = options.flag_name;
+                    }
+                    if (options.git) {
+                        postJson.git = options.git;
+                    }
+                    if (options.run_at) {
+                        postJson.run_at = options.run_at;
+                    }
+                    if (options.service_name) {
+                        postJson.service_name = options.service_name;
+                    }
+                    if (options.service_number) {
+                        postJson.service_number = options.service_number;
+                    }
+                    if (options.service_job_id) {
+                        postJson.service_job_id = options.service_job_id;
+                    }
+                    if (options.service_pull_request) {
+                        postJson.service_pull_request = options.service_pull_request;
+                    }
+                    if (options.repo_token) {
+                        postJson.repo_token = options.repo_token;
+                    }
+                    if (options.parallel) {
+                        postJson.parallel = options.parallel;
+                    }
+                    if (options.flag_name) {
+                        postJson.flag_name = options.flag_name;
+                    }
+                    coveralls.sendToCoveralls(postJson, (err, response, body) => {
+                        if (response.statusCode >= 400) {
+                            core.setFailed(`Bad response: ${response.statusCode} ${body}`);
+                        }
+                        if (err) {
+                            core.setFailed(err);
+                        }
+                        else {
+                            core.setOutput('coveralls-api-result', body);
+                        }
+                    });
+                });
+            }
+            else {
+                coveralls.handleInput(adjustedFile, (err, body) => {
+                    if (err) {
+                        core.setFailed(err);
+                    }
+                    else {
+                        core.setOutput('coveralls-api-result', body);
+                    }
+                });
+            }
         }
         catch (error) {
             core.setFailed(error.message);

--- a/src/run.ts
+++ b/src/run.ts
@@ -78,34 +78,109 @@ export async function run() {
 
     process.env.COVERALLS_PARALLEL = process.env.COVERALLS_PARALLEL || core.getInput('parallel');
 
+    const defaultPath = './coverage/lcov.info';
+    const defaultType = 'lcov';
+
+    const pathToFile = core.getInput('path-to-file');
     const pathToLcov = core.getInput('path-to-lcov');
 
-    if (pathToLcov == '') {
-      throw new Error("No Lcov path specified.");
+    const formatInput = core.getInput('coverage-format');
+    const filetype = formatInput !== defaultType ? formatInput : defaultType;
+
+    if (filetype !== defaultType && filetype !== 'raw') {
+      throw new Error(`Unsupported file format: ${filetype}`);
     }
 
-    console.log(`Using lcov file: ${pathToLcov}`);
+    // for compatibility with the name path-to-lcov - go through these steps
+    // 1. use 'path-to-file' if its not the default path
+    // 2. use 'path-to-lcov' if its not the default
+    // 3. use 'path-to-file' (which will be the default at this point in time - but i made it more explicit)
+    const pathToUse = pathToFile !== defaultPath ? pathToFile : ((pathToLcov !== defaultPath) ? pathToLcov : pathToFile);
+    if (pathToUse == '') {
+        throw new Error("No file path specified.");
+    }
+
+    console.log(`Using ${filetype} file: ${pathToUse}`);
 
     let file;
 
     try {
-      file = fs.readFileSync(pathToLcov, 'utf8');
+      file = fs.readFileSync(pathToUse, 'utf8');
     } catch (err) {
-      throw new Error("Lcov file not found.");
+      throw new Error(`${filetype} file not found.`);
     }
-
 
     const basePath = core.getInput('base-path');
     const adjustedFile = basePath ? adjustLcovBasePath(file, basePath) : file;
 
-    coveralls.handleInput(adjustedFile, (err: string, body: string) => {
-      if(err){
-        core.setFailed(err);
-      } else {
-        core.setOutput('coveralls-api-result', body);
-      }
-    });
+    if (filetype === 'raw') {
+      coveralls.getOptions((err: string, options: any) => {
+        if (err) {
+          core.setFailed(err);
+        }
+    
+        const postJson = JSON.parse(adjustedFile);
+    
+        if (options.flag_name) {
+          postJson.flag_name = options.flag_name;
+        }
+        
+        if (options.git) {
+          postJson.git = options.git;
+        }
+    
+        if (options.run_at) {
+          postJson.run_at = options.run_at;
+        }
+    
+        if (options.service_name) {
+          postJson.service_name = options.service_name;
+        }
+        
+        if (options.service_number) {
+          postJson.service_number = options.service_number;
+        }
+        
+        if (options.service_job_id) {
+          postJson.service_job_id = options.service_job_id;
+        }
+    
+        if (options.service_pull_request) {
+          postJson.service_pull_request = options.service_pull_request;
+        }
+    
+        if (options.repo_token) {
+          postJson.repo_token = options.repo_token;
+        }
+    
+        if (options.parallel) {
+          postJson.parallel = options.parallel;
+        }
+        if (options.flag_name) {
+          postJson.flag_name = options.flag_name;
+        }
 
+        coveralls.sendToCoveralls(postJson, (err: string, response: any, body: string) => {
+          if (response.statusCode >= 400) {
+            core.setFailed(`Bad response: ${response.statusCode} ${body}`);
+          }
+  
+          if(err){
+            core.setFailed(err);
+          } else {
+            core.setOutput('coveralls-api-result', body);
+          }
+        });
+      });
+    } else {
+      coveralls.handleInput(adjustedFile, (err: string, body: string) => {
+        if(err){
+          core.setFailed(err);
+        } else {
+          core.setOutput('coveralls-api-result', body);
+        }
+      });
+    }
   } catch (error) {
     core.setFailed(error.message);
   }


### PR DESCRIPTION
Add support for user-provided raw JSON coverage file (such as the file generated by the `coveralls-maven-plugin`).

This PR uses some code authored by @ly-cultureiq in PR #25 .

- Update README with instructions for raw file and Java example