### PR TITLE
doc: Mark `path-to-lcov` required to match YML

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The action's step needs to run after your test suite has outputted an LCOV file.
 | Name                  | Requirement | Description |
 | --------------------- | ----------- | ----------- |
 | `github-token`        | _required_ | Must be in form `github-token: ${{ secrets.GITHUB_TOKEN }}`; Coveralls uses this token to verify the posted coverage data on the repo and create a new check based on the results. It is built into Github Actions and does not need to be manually specified in your secrets store. [More Info](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token)|
-| `path-to-lcov`        | _optional_ | Default: "./coverage/lcov.info". Local path to the lcov output file produced by your test suite. An error will be thrown if the file can't be found. This is the file that will be sent to the Coveralls API. |
+| `path-to-lcov`        | _required_ | Default: "./coverage/lcov.info". Local path to the lcov output file produced by your test suite. An error will be thrown if the file can't be found. This is the file that will be sent to the Coveralls API. |
 | `flag-name`           | _optional (unique required if parallel)_ | Job flag name, e.g. "Unit", "Functional", or "Integration". Will be shown in the Coveralls UI. |
 | `parallel`            | _optional_ | Set to true for parallel (or matrix) based steps, where multiple posts to Coveralls will be performed in the check. `flag-name` needs to be set and unique, e.g. `flag-name: run-${{ matrix.test_number }}` |
 | `parallel-finished`   | _optional_ | Set to true in the last job, after the other parallel jobs steps have completed, this will send a webhook to Coveralls to set the build complete. |


### PR DESCRIPTION
The `actions.yml` has it as required https://github.com/coverallsapp/github-action/blob/8cbef1dea373ebce56de0a14c68d6267baa10b44/action.yml#L10
Just noticed in VS Code because it was giving an error on the schema validation. Alternately the actions.yml could be updated to make it not required since it does have a default