### PR TITLE
fix: Throw read file sync error instead of throwing static error messages

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -86,15 +86,7 @@ export async function run() {
 
     console.log(`Using lcov file: ${pathToLcov}`);
 
-    let file;
-
-    try {
-      file = fs.readFileSync(pathToLcov, 'utf8');
-    } catch (err) {
-      throw new Error("Lcov file not found.");
-    }
-
-
+    const file = fs.readFileSync(pathToLcov, 'utf8');
     const basePath = core.getInput('base-path');
     const adjustedFile = basePath ? adjustLcovBasePath(file, basePath) : file;
 


### PR DESCRIPTION
## Why

Because `err` contains the actual error message. Moreover, `readFileSync` doesn't only fail if the file doesn't exists.
