### PR TITLE
feat: add addition override parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ The action's step needs to run after your test suite has outputted an LCOV file.
 | `parallel-finished`   | _optional_ | Set to true in the last job, after the other parallel jobs steps have completed, this will send a webhook to Coveralls to set the build complete. |
 | `coveralls-endpoint`  | _optional_ | Hostname and protocol: `https://<host>`; Specifies a [Coveralls Enterprise](https://enterprise.coveralls.io/) hostname. |
 | `base-path`           | _optional_ | Path to the root folder of the project the coverage was collected in. Should be used in monorepos so that coveralls can process the LCOV correctly (e.g. packages/my-project) |
+| `git-branch`          | _optional_ | Default: GITHUB_REF environment variable. Override the branch name. |
+| `git-commit`          | _optional_ | Default: GITHUB_SHA environment variable. Override the commit sha. |
 
 ### Outputs:
 

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,12 @@ inputs:
   base-path:
     description: 'The root folder of the project that originally ran the tests'
     required: false
+  git-branch:
+    description: 'Override the branch name'
+    required: false
+  git-commit:
+    description: 'Override the commit sha'
+    required: false
 outputs:
   coveralls-api-result:
     description: 'Result status of Coveralls API post.'

--- a/lib/run.js
+++ b/lib/run.js
@@ -40,7 +40,15 @@ function run() {
                 console.log("Event Name: " + process.env.GITHUB_EVENT_NAME);
                 console.log(event);
             }
-            if (process.env.GITHUB_EVENT_NAME == 'pull_request') {
+            const gitCommit = core.getInput('git-commit');
+            const gitBranch = core.getInput('git-branch');
+            if (gitCommit && gitCommit != '') {
+                process.env.COVERALLS_GIT_COMMIT = gitCommit;
+            }
+            if (gitBranch && gitBranch != '') {
+                process.env.COVERALLS_GIT_BRANCH = gitBranch;
+            }
+            if (process.env.GITHUB_EVENT_NAME == 'pull_request' || process.env.GITHUB_EVENT_NAME == 'pull_request_target') {
                 process.env.CI_PULL_REQUEST = JSON.parse(event).number;
             }
             const endpoint = core.getInput('coveralls-endpoint');

--- a/src/run.ts
+++ b/src/run.ts
@@ -35,7 +35,18 @@ export async function run() {
       console.log(event);
     }
 
-    if (process.env.GITHUB_EVENT_NAME == 'pull_request') {
+    const gitCommit = core.getInput('git-commit');
+    const gitBranch = core.getInput('git-branch');
+    
+    if (gitCommit && gitCommit != '') {
+      process.env.COVERALLS_GIT_COMMIT = gitCommit;
+    }
+
+    if (gitBranch && gitBranch != '') {
+      process.env.COVERALLS_GIT_BRANCH = gitBranch;
+    }
+
+    if (process.env.GITHUB_EVENT_NAME == 'pull_request' || process.env.GITHUB_EVENT_NAME == 'pull_request_target') {
       process.env.CI_PULL_REQUEST = JSON.parse(event).number;
     }
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -50,10 +50,6 @@ export async function run() {
       process.env.CI_PULL_REQUEST = JSON.parse(event).number;
     }
 
-    console.log(`Branch: ${process.env.COVERALLS_GIT_BRANCH}`)
-    console.log(`Commit: ${process.env.COVERALLS_GIT_COMMIT}`)
-    console.log(`CI_PULL_REQUEST: ${process.env.CI_PULL_REQUEST}`)
-
     const endpoint = core.getInput('coveralls-endpoint');
     if (endpoint != '') {
       process.env.COVERALLS_ENDPOINT = endpoint;

--- a/src/run.ts
+++ b/src/run.ts
@@ -37,7 +37,7 @@ export async function run() {
 
     const gitCommit = core.getInput('git-commit');
     const gitBranch = core.getInput('git-branch');
-    
+
     if (gitCommit && gitCommit != '') {
       process.env.COVERALLS_GIT_COMMIT = gitCommit;
     }
@@ -49,6 +49,10 @@ export async function run() {
     if (process.env.GITHUB_EVENT_NAME == 'pull_request' || process.env.GITHUB_EVENT_NAME == 'pull_request_target') {
       process.env.CI_PULL_REQUEST = JSON.parse(event).number;
     }
+
+    console.log(`Branch: ${process.env.COVERALLS_GIT_BRANCH}`)
+    console.log(`Commit: ${process.env.COVERALLS_GIT_COMMIT}`)
+    console.log(`CI_PULL_REQUEST: ${process.env.CI_PULL_REQUEST}`)
 
     const endpoint = core.getInput('coveralls-endpoint');
     if (endpoint != '') {


### PR DESCRIPTION
This PR allows users to override both the commit and the branch name if they wish to do so.

In our use-case this allows us to use `pull_request_target` as a [trigger](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target) for GH actions.