### PR TITLE
Fix action schema

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: true
   path-to-lcov:
     description: 'Path to lcov file'
-    required: true
+    required: false
     default: './coverage/lcov.info'
   flag-name:
     description: 'Job flag name, e.g. "Unit", "Functional", or "Integration". Will be shown in the Coveralls UI.'


### PR DESCRIPTION
Hello,
The `path-to-lcov` argument had `required` set to `true`. This has a default key, so there is no need to obligate the user to set a path.
This leads to errors when using the action along with workflows linter.