### PR TITLE
suggest always passing `finish` step in README?

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ jobs:
 
   finish:
     needs: test
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished


### PR DESCRIPTION
This seems like the intended behavior of `parallel-finished`. It means
parallel-finished might run multiple times if the user explicitly
re-runs failed jobs, but means partial coverage will get updated once
all of the CI runs end (even if few or none of them succeeded and
uploaded coverage).

I wasn't certain if this should suggest only doing this for `always() && github.event_name == 'pull_request'`, or some other combination of options, depending on how the diff-changed algorithm works across partially-failed builds. But this seemed like a simple enough improvement regardless.