### PR TITLE
fix: github-token default to `${{ github.token }}`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,6 @@ author: 'Nick Merwin (Coveralls, Inc.)'
 inputs:
   github-token:
     description: 'Put secrets.GITHUB_TOKEN here'
-    required: true
     default: ${{ github.token }}
   path-to-lcov:
     description: 'Path to lcov file'

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,7 @@ inputs:
   github-token:
     description: 'Put secrets.GITHUB_TOKEN here'
     required: true
+    default: ${{ github.token }}
   path-to-lcov:
     description: 'Path to lcov file'
     required: false


### PR DESCRIPTION
Precedent https://github.com/actions/checkout/blob/main/action.yml#L24