### PR TITLE
feat: add allow-empty option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The action's step needs to run after your test suite has outputted an LCOV file.
 | `parallel-finished`   | _optional_ | Set to true in the last job, after the other parallel jobs steps have completed, this will send a webhook to Coveralls to set the build complete. |
 | `carryforward`        | _optional_ | Comma separated flags used to carryforward results from previous builds if some of the parallel jobs are missing. Used only with `parallel-finished`. |
 | `coveralls-endpoint`  | _optional_ | Hostname and protocol: `https://<host>`; Specifies a [Coveralls Enterprise](https://enterprise.coveralls.io/) hostname. |
+| `allow-empty`         | _optional_ | Default: `false`. Don't fail if coverage report is empty or contains no coverage data. |
 | `base-path`           | _optional_ | Path to the root folder of the project the coverage was collected in. Should be used in monorepos so that coveralls can process the LCOV correctly (e.g. packages/my-project) |
 | `git-branch`          | _optional_ | Default: GITHUB_REF environment variable. Override the branch name. |
 | `git-commit`          | _optional_ | Default: GITHUB_SHA environment variable. Override the commit SHA. |

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: 'Coveralls Enterprise server (more info: https://enterprise.coveralls.io)'
     required: false
     default: 'https://coveralls.io'
+  allow-empty:
+    description: "Don't fail when coverage report file is empty or contains no data"
+    required: false
+    default: false
   base-path:
     description: 'The root folder of the project that originally ran the tests'
     required: false
@@ -70,7 +74,10 @@ runs:
     - name: Install coveralls reporter (Linux)
       if: runner.os == 'Linux'
       shell: bash
-      run: curl -sL https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-linux.tar.gz | tar xz -C /usr/local/bin
+      run: |
+        mkdir -p ~/bin/
+        curl -sL https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-linux.tar.gz | tar xz -C ~/bin
+        echo ~/bin >> $GITHUB_PATH
 
     - name: Install coveralls reporter (Windows)
       if: startsWith(runner.os, 'Windows')
@@ -100,6 +107,7 @@ runs:
       run: >-
         coveralls
         ${{ inputs.debug == 'true' && '--debug' || '' }}
+        ${{ inputs.allow-empty == 'true' && '--allow-empty' || '' }}
         ${{ inputs.base-path && format('--base-path {0}', inputs.base-path) || '' }}
         ${{ (inputs.file || inputs.path-to-lcov) && format('--file {0}', inputs.file || inputs.path-to-lcov) || '' }}
         ${{ inputs.format && format('--format {0}', inputs.format) || '' }}


### PR DESCRIPTION
**Summary**

- [x] Add `allow-empty` option (available since coverage-reporter 0.3.3)
- [x] Don't use `/usr/local/bin` for Linux runner, use `~/bin` and update GITHUB_PATH instead