### PR TITLE
feat: add fail-on-error option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The action's step needs to run after your test suite has outputted an LCOV file.
 | `compare-sha`         | _optional_ | Commit SHA to compare coverage with. |
 | `debug`               | _optional_ | Default: `false`. Set to `true` to enable debug logging. |
 | `measure`             | _optional_ | Default: `false`. Set to `true` to enable time time measurement logging. |
+| `fail-on-error`       | _optional_ | Default: `true`. Set to `false` to avoid CI failure when upload fails due to any errors. |
 
 ### Outputs:
 

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,10 @@ inputs:
     description: 'Show execution time of parsing and reporting'
     required: false
     default: false
+  fail-on-error:
+    description: 'Whether to fail (exit code 1) on any issues while uploading the coverage'
+    required: false
+    default: true
 outputs:
   coveralls-api-result:
     description: 'Result status of Coveralls API post.'
@@ -104,7 +108,11 @@ runs:
     - name: Done report
       if: inputs.parallel-finished == 'true'
       shell: bash
-      run: coveralls done ${{ inputs.debug == 'true' && '--debug' || '' }} ${{ inputs.measure == 'true' && '--measure' || '' }}
+      run: >-
+        coveralls done
+        ${{ inputs.debug == 'true' && '--debug' || '' }}
+        ${{ inputs.measure == 'true' && '--measure' || '' }}
+        ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }}
       env:
         COVERALLS_DEBUG: ${{ inputs.debug }}
         COVERALLS_CARRYFORWARD_FLAGS: ${{ inputs.carryforward }}
@@ -122,6 +130,7 @@ runs:
         coveralls report
         ${{ inputs.debug == 'true' && '--debug' || '' }}
         ${{ inputs.measure == 'true' && '--measure' || '' }}
+        ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }}
         ${{ inputs.allow-empty == 'true' && '--allow-empty' || '' }}
         ${{ inputs.base-path && format('--base-path {0}', inputs.base-path) || '' }}
         ${{ inputs.format && format('--format {0}', inputs.format) || '' }}


### PR DESCRIPTION
With `fail-on-error: false` you can skip upload and parsing errors of coverage reporter.

Available since `coverage-reporter 0.6.3`