### PR TITLE
feat: add create-build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The action's step needs to run after your test suite has outputted an LCOV file.
 | `flag-name`           | _optional (unique required if parallel)_ | Job flag name, e.g. "Unit", "Functional", or "Integration". Will be shown in the Coveralls UI. |
 | `parallel`            | _optional_ | Set to true for parallel (or matrix) based steps, where multiple posts to Coveralls will be performed in the check. `flag-name` needs to be set and unique, e.g. `flag-name: run ${{ join(matrix.*, ' - ') }}` |
 | `parallel-finished`   | _optional_ | Set to true in the last job, after the other parallel jobs steps have completed, this will send a webhook to Coveralls to set the build complete. |
+| `create-build`        | _optional_ | Create the empty build if running with `parallel-finished: true` (if not exists) |
 | `carryforward`        | _optional_ | Comma separated flags used to carryforward results from previous builds if some of the parallel jobs are missing. Used only with `parallel-finished`. |
 | `coveralls-endpoint`  | _optional_ | Hostname and protocol: `https://<host>`; Specifies a [Coveralls Enterprise](https://enterprise.coveralls.io/) hostname. |
 | `allow-empty`         | _optional_ | Default: `false`. Don't fail if coverage report is empty or contains no coverage data. |

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,10 @@ inputs:
     description: 'Whether to fail (exit code 1) on any issues while uploading the coverage'
     required: false
     default: true
+  create-build:
+    description: 'When calling parallel-done webhook crate the build if it is missing'
+    required: false
+    default: false
 outputs:
   coveralls-api-result:
     description: 'Result status of Coveralls API post.'
@@ -116,6 +120,7 @@ runs:
         ${{ inputs.debug == 'true' && '--debug' || '' }}
         ${{ inputs.measure == 'true' && '--measure' || '' }}
         ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }}
+        ${{ inputs.create-build == 'true' && '--create-build' || '' }}
       env:
         COVERALLS_DEBUG: ${{ inputs.debug }}
         COVERALLS_CARRYFORWARD_FLAGS: ${{ inputs.carryforward }}


### PR DESCRIPTION
This option (`create-build`) is useful if you want to report a build and carry-forward all flags from previous build. For example, using the following configuration:

```yml
# .github/workflows/ci.yml

...

- coverallsapp/github-action@v2
  with:
    parallel-finished: true
    create-build: true
    carryforward: all
```