### PR TITLE
Update to be compatible with alpine distros

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,7 @@ runs:
         cd ~/bin/
         curl -sLO https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-linux.tar.gz
         curl -sLO https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-checksums.txt
-        cat coveralls-checksums.txt | grep coveralls-linux.tar.gz | sha256sum --check
+        cat coveralls-checksums.txt | grep coveralls-linux.tar.gz | sha256sum -c
         tar -xzf coveralls-linux.tar.gz
         rm coveralls-checksums.txt
         echo ~/bin >> $GITHUB_PATH


### PR DESCRIPTION
Use -c instead of --check so sha256sum will work on both alpine and ubuntu distros