### PR TITLE
add build number to inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
   flag-name:
     description: 'Job flag name, e.g. "Unit", "Functional", or "Integration". Will be shown in the Coveralls UI.'
     required: false
+  build-number:
+    description: 'Override the build number autodetected by CI. This is useful if your CI tool assigns a different build number per parallel build.'
+    required: false
   parallel:
     description: 'Set to true if you are running parallel jobs, then use "parallel-finished: true" for the last action.'
     required: false
@@ -114,6 +117,7 @@ runs:
         coveralls done
         ${{ inputs.debug == 'true' && '--debug' || '' }}
         ${{ inputs.measure == 'true' && '--measure' || '' }}
+        ${{ inputs.build-number && format('--build-number {0}', inputs.build-number) || '' }}
         ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }}
       env:
         COVERALLS_DEBUG: ${{ inputs.debug }}
@@ -135,6 +139,7 @@ runs:
         ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }}
         ${{ inputs.allow-empty == 'true' && '--allow-empty' || '' }}
         ${{ inputs.base-path && format('--base-path {0}', inputs.base-path) || '' }}
+        ${{ inputs.build-number && format('--build-number {0}', inputs.build-number) || '' }}
         ${{ inputs.format && format('--format {0}', inputs.format) || '' }}
         ${{ inputs.file || inputs.path-to-lcov }}
         ${{ inputs.files }}


### PR DESCRIPTION
For monorepos the github actions job level path filters are cumbersome to the point that my predecessors opted to make all coverage tests just be their own workflows. This has the artifact of every commit and the associated job triggers multi-pushing reports under different build ids where from our perspective they are part of the same commit/run.

This PR let's use overload build-number for those cases
