### PR TITLE
Allow pinning of coverage reporter version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,26 +12,27 @@ The action's step needs to run after your test suite has outputted an LCOV file.
 
 ### Inputs:
 
-| Name                  | Requirement | Description |
-| --------------------- | ----------- | ----------- |
-| `github-token`        | _required_ | Default if not specified: `${{ github.token }}`. Can be also specified this way: `github-token: ${{ secrets.GITHUB_TOKEN }}`; Coveralls uses this token to verify the appropriate repo at Coveralls and send any new status updates based on your coverage results. This variable is built into Github Actions, so __do not add it to your secrets store__. [More Info](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token)|
-| `file`        | _optional_ | Default: all coverage files that could be found. Local path to the coverage report file produced by your test suite. An error will be thrown if no file was found. This is the file that will be sent to the Coveralls API. Leave empty if you want to combine many files reports. |
-| `files`       | _optional_ | Default: all coverage files that could be found. Space-separated list of coverage report files produced by your test suite. Example: `files: coverage/test1.lcov coverage/test2.lcov` |
-| `format`              | _optional_ | Force coverage report file format. If not specified, coveralls will try to detect the format based on file extension and/or content. Possible values: `lcov`, `simplecov`, `cobertura`, `jacoco`, `gcov`, `golang`, `python`. See also [actual supported coverage report formats list](https://github.com/coverallsapp/coverage-reporter#supported-coverage-report-formats). |
-| `flag-name`           | _optional (unique required if parallel)_ | Job flag name, e.g. "Unit", "Functional", or "Integration". Will be shown in the Coveralls UI. |
-| `parallel`            | _optional_ | Set to true for parallel (or matrix) based steps, where multiple posts to Coveralls will be performed in the check. `flag-name` needs to be set and unique, e.g. `flag-name: run ${{ join(matrix.*, ' - ') }}` |
-| `parallel-finished`   | _optional_ | Set to true in the last job, after the other parallel jobs steps have completed, this will send a webhook to Coveralls to set the build complete. |
-| `carryforward`        | _optional_ | Comma separated flags used to carryforward results from previous builds if some of the parallel jobs are missing. Used only with `parallel-finished`. |
-| `coveralls-endpoint`  | _optional_ | Hostname and protocol: `https://<host>`; Specifies a [Coveralls Enterprise](https://enterprise.coveralls.io/) hostname. |
-| `allow-empty`         | _optional_ | Default: `false`. Don't fail if coverage report is empty or contains no coverage data. |
-| `base-path`           | _optional_ | Path to the root folder of the project the coverage was collected in. Should be used in monorepos so that coveralls can process the LCOV correctly (e.g. packages/my-project) |
-| `git-branch`          | _optional_ | Default: GITHUB_REF environment variable. Override the branch name. |
-| `git-commit`          | _optional_ | Default: GITHUB_SHA environment variable. Override the commit SHA. |
-| `compare-ref`         | _optional_ | Branch name to compare coverage with. Specify if you want to always check coverage change for PRs against one branch. |
-| `compare-sha`         | _optional_ | Commit SHA to compare coverage with. |
-| `debug`               | _optional_ | Default: `false`. Set to `true` to enable debug logging. |
-| `measure`             | _optional_ | Default: `false`. Set to `true` to enable time time measurement logging. |
-| `fail-on-error`       | _optional_ | Default: `true`. Set to `false` to avoid CI failure when upload fails due to any errors. |
+| Name                        | Requirement | Description |
+| --------------------------- | ----------- | ----------- |
+| `github-token`              | _required_ | Default if not specified: `${{ github.token }}`. Can be also specified this way: `github-token: ${{ secrets.GITHUB_TOKEN }}`; Coveralls uses this token to verify the appropriate repo at Coveralls and send any new status updates based on your coverage results. This variable is built into Github Actions, so __do not add it to your secrets store__. [More Info](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token)|
+| `file`                      | _optional_ | Default: all coverage files that could be found. Local path to the coverage report file produced by your test suite. An error will be thrown if no file was found. This is the file that will be sent to the Coveralls API. Leave empty if you want to combine many files reports. |
+| `files`                     | _optional_ | Default: all coverage files that could be found. Space-separated list of coverage report files produced by your test suite. Example: `files: coverage/test1.lcov coverage/test2.lcov` |
+| `format`                    | _optional_ | Force coverage report file format. If not specified, coveralls will try to detect the format based on file extension and/or content. Possible values: `lcov`, `simplecov`, `cobertura`, `jacoco`, `gcov`, `golang`, `python`. See also [actual supported coverage report formats list](https://github.com/coverallsapp/coverage-reporter#supported-coverage-report-formats). |
+| `flag-name`                 | _optional (unique required if parallel)_ | Job flag name, e.g. "Unit", "Functional", or "Integration". Will be shown in the Coveralls UI. |
+| `parallel`                  | _optional_ | Set to true for parallel (or matrix) based steps, where multiple posts to Coveralls will be performed in the check. `flag-name` needs to be set and unique, e.g. `flag-name: run ${{ join(matrix.*, ' - ') }}` |
+| `parallel-finished`         | _optional_ | Set to true in the last job, after the other parallel jobs steps have completed, this will send a webhook to Coveralls to set the build complete. |
+| `carryforward`              | _optional_ | Comma separated flags used to carryforward results from previous builds if some of the parallel jobs are missing. Used only with `parallel-finished`. |
+| `coveralls-endpoint`        | _optional_ | Hostname and protocol: `https://<host>`; Specifies a [Coveralls Enterprise](https://enterprise.coveralls.io/) hostname. |
+| `allow-empty`               | _optional_ | Default: `false`. Don't fail if coverage report is empty or contains no coverage data. |
+| `base-path`                 | _optional_ | Path to the root folder of the project the coverage was collected in. Should be used in monorepos so that coveralls can process the LCOV correctly (e.g. packages/my-project) |
+| `git-branch`                | _optional_ | Default: GITHUB_REF environment variable. Override the branch name. |
+| `git-commit`                | _optional_ | Default: GITHUB_SHA environment variable. Override the commit SHA. |
+| `compare-ref`               | _optional_ | Branch name to compare coverage with. Specify if you want to always check coverage change for PRs against one branch. |
+| `compare-sha`               | _optional_ | Commit SHA to compare coverage with. |
+| `debug`                     | _optional_ | Default: `false`. Set to `true` to enable debug logging. |
+| `measure`                   | _optional_ | Default: `false`. Set to `true` to enable time time measurement logging. |
+| `fail-on-error`             | _optional_ | Default: `true`. Set to `false` to avoid CI failure when upload fails due to any errors. |
+| `coverage-reporter-version` | _optional_ | Default: `latest`. Version of coverage-reporter to use. Make sure to prefix the version number with 'v'. For example: v0.6.9. Not available currently on macOS. |
 
 ### Outputs:
 

--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,7 @@ inputs:
     required: false
     default: 'true'
   coverage-reporter-version:
-    description: 'Version of coverage-reporter to user'
+    description: "Version of coverage-reporter to use. Make sure to prefix the version number with 'v'. For example: v0.6.9"
     required: false
     default: 'latest'
 branding:
@@ -90,12 +90,14 @@ runs:
 
     - name: Install coveralls reporter (Linux)
       if: runner.os == 'Linux'
+      env:
+        COVERAGE_REPORTER_VERSION: ${{ inputs.coverage-reporter-version }}
       shell: bash
       run: |
         mkdir -p ~/bin/
         cd ~/bin/
-        curl -sLO https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-linux.tar.gz
-        curl -sLO https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-checksums.txt
+        curl -sLO https://github.com/coverallsapp/coverage-reporter/releases/download/${COVERAGE_REPORTER_VERSION}/coveralls-linux.tar.gz
+        curl -sLO https://github.com/coverallsapp/coverage-reporter/releases/download/${COVERAGE_REPORTER_VERSION}/coveralls-checksums.txt
         cat coveralls-checksums.txt | grep coveralls-linux.tar.gz | sha256sum --check
         tar -xzf coveralls-linux.tar.gz
         rm coveralls-checksums.txt
@@ -103,12 +105,14 @@ runs:
 
     - name: Install coveralls reporter (Windows)
       if: startsWith(runner.os, 'Windows')
+      env:
+        COVERAGE_REPORTER_VERSION: ${{ inputs.coverage-reporter-version }}
       shell: pwsh
       run: |
         New-Item -Path $env:HOME\bin -ItemType directory -Force
         Push-Location $env:HOME\bin
-        Invoke-WebRequest -Uri "https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-windows.exe" -OutFile "coveralls.exe"
-        Invoke-WebRequest -Uri "https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-checksums.txt" -OutFile "sha256sums.txt"
+        Invoke-WebRequest -Uri "https://github.com/coverallsapp/coverage-reporter/releases/download/${COVERAGE_REPORTER_VERSION}/coveralls-windows.exe" -OutFile "coveralls.exe"
+        Invoke-WebRequest -Uri "https://github.com/coverallsapp/coverage-reporter/releases/download/${COVERAGE_REPORTER_VERSION}/coveralls-checksums.txt" -OutFile "sha256sums.txt"
         (Get-FileHash coveralls.exe).Hash -eq (Get-Content ./sha256sums.txt | Where-Object{$_ -match 'windows.exe'} | ForEach-Object{($_ -split "\s+")[0]})
         Remove-Item *.txt -Force
         echo $env:HOME\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/action.yml
+++ b/action.yml
@@ -96,8 +96,14 @@ runs:
       run: |
         mkdir -p ~/bin/
         cd ~/bin/
-        curl -sLO https://github.com/coverallsapp/coverage-reporter/releases/download/${COVERAGE_REPORTER_VERSION}/coveralls-linux.tar.gz
-        curl -sLO https://github.com/coverallsapp/coverage-reporter/releases/download/${COVERAGE_REPORTER_VERSION}/coveralls-checksums.txt
+        if [ $COVERAGE_REPORTER_VERSION == "latest" ]
+        then
+          asset_path=latest/download
+        else
+          asset_path="download/${COVERAGE_REPORTER_VERSION}"
+        fi
+        curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-linux.tar.gz"
+        curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-checksums.txt"
         cat coveralls-checksums.txt | grep coveralls-linux.tar.gz | sha256sum --check
         tar -xzf coveralls-linux.tar.gz
         rm coveralls-checksums.txt
@@ -111,8 +117,13 @@ runs:
       run: |
         New-Item -Path $env:HOME\bin -ItemType directory -Force
         Push-Location $env:HOME\bin
-        Invoke-WebRequest -Uri "https://github.com/coverallsapp/coverage-reporter/releases/download/$env:COVERAGE_REPORTER_VERSION/coveralls-windows.exe" -OutFile "coveralls.exe"
-        Invoke-WebRequest -Uri "https://github.com/coverallsapp/coverage-reporter/releases/download/$env:COVERAGE_REPORTER_VERSION/coveralls-checksums.txt" -OutFile "sha256sums.txt"
+        if($env:COVERAGE_REPORTER_VERSION -eq "latest") {
+          Invoke-WebRequest -Uri "https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-windows.exe" -OutFile "coveralls.exe"
+          Invoke-WebRequest -Uri "https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-checksums.txt" -OutFile "sha256sums.txt"
+        } else {
+          Invoke-WebRequest -Uri "https://github.com/coverallsapp/coverage-reporter/releases/download/$env:COVERAGE_REPORTER_VERSION/coveralls-windows.exe" -OutFile "coveralls.exe"
+          Invoke-WebRequest -Uri "https://github.com/coverallsapp/coverage-reporter/releases/download/$env:COVERAGE_REPORTER_VERSION/coveralls-checksums.txt" -OutFile "sha256sums.txt"
+        }
         (Get-FileHash coveralls.exe).Hash -eq (Get-Content ./sha256sums.txt | Where-Object{$_ -match 'windows.exe'} | ForEach-Object{($_ -split "\s+")[0]})
         Remove-Item *.txt -Force
         echo $env:HOME\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/action.yml
+++ b/action.yml
@@ -111,8 +111,8 @@ runs:
       run: |
         New-Item -Path $env:HOME\bin -ItemType directory -Force
         Push-Location $env:HOME\bin
-        Invoke-WebRequest -Uri "https://github.com/coverallsapp/coverage-reporter/releases/download/${COVERAGE_REPORTER_VERSION}/coveralls-windows.exe" -OutFile "coveralls.exe"
-        Invoke-WebRequest -Uri "https://github.com/coverallsapp/coverage-reporter/releases/download/${COVERAGE_REPORTER_VERSION}/coveralls-checksums.txt" -OutFile "sha256sums.txt"
+        Invoke-WebRequest -Uri "https://github.com/coverallsapp/coverage-reporter/releases/download/$env:COVERAGE_REPORTER_VERSION/coveralls-windows.exe" -OutFile "coveralls.exe"
+        Invoke-WebRequest -Uri "https://github.com/coverallsapp/coverage-reporter/releases/download/$env:COVERAGE_REPORTER_VERSION/coveralls-checksums.txt" -OutFile "sha256sums.txt"
         (Get-FileHash coveralls.exe).Hash -eq (Get-Content ./sha256sums.txt | Where-Object{$_ -match 'windows.exe'} | ForEach-Object{($_ -split "\s+")[0]})
         Remove-Item *.txt -Force
         echo $env:HOME\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append

--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,11 @@ runs:
         brew tap coverallsapp/coveralls --quiet
         brew install coveralls --quiet
 
+    - name: Report coverage-reporter-version information for macOS
+      if: ${{ runner.os == 'macOS' && inputs.coverage-reporter-version != 'latest' }}
+      shell: bash
+      run: echo "The coverage-reporter-version parameter is not available on macOS"
+
     - name: Install coveralls reporter (Linux)
       if: runner.os == 'Linux'
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,10 @@ inputs:
     description: 'Whether to fail (exit code 1) on any issues while uploading the coverage'
     required: false
     default: 'true'
+  coverage-reporter-version:
+    description: 'Version of coverage-reporter to user'
+    required: false
+    default: 'latest'
 branding:
   color: 'green'
   icon: 'percent'

--- a/action.yml
+++ b/action.yml
@@ -86,7 +86,9 @@ runs:
     - name: Report coverage-reporter-version information for macOS
       if: ${{ runner.os == 'macOS' && inputs.coverage-reporter-version != 'latest' }}
       shell: bash
-      run: echo "The coverage-reporter-version parameter is not available on macOS"
+      run: |
+        echo "The coverage-reporter-version parameter is not available on macOS" >&2
+        exit 1
 
     - name: Install coveralls reporter (Linux)
       if: runner.os == 'Linux'


### PR DESCRIPTION
This add a `coverage-reporter-version` parameter that allows users to specify a version of [coverage-reporter](https://github.com/coverallsapp/coverage-reporter) to use. It will default to the latest version if not specified. This currently only works for Linux and Windows until versioning can be added to the Coveralls Homebrew tap.