### PR TITLE
docs: fix the action version

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ jobs:
           - 1
           - 2
     steps:
-    - uses: actions/checkout@3
+    - uses: actions/checkout@v4
     - name: Use Node.js 16.x
-      uses: actions/setup-node@3
+      uses: actions/setup-node@v3
       with:
         node-version: 16.x
 


### PR DESCRIPTION
prepend the `v`. I copied and pasted the example to my workflow, and then it took me quite a while to figure out the github action errors:

```
Error: Unable to resolve action `actions/checkout@4`, unable to find version `4`. Unable to resolve action `actions/setup-node@3`, unable to find version `3`
```