### PR TITLE
Extend behavior of `fail-on-error` option to setup failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,89 @@
+name: Test GitHub Action
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test-action:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        action: [install, report, done]
+        fail_on_error: [true, false]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up environment
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          echo "Running on Linux"
+      - name: Set up environment
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        run: |
+          echo "Running on macOS"
+      - name: Set up environment
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          echo "Running on Windows"
+
+      - name: Run Test Action
+        uses: ./
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-error: ${{ matrix.fail_on_error }}
+          debug: true
+        env:
+          CI: true
+
+      - name: Simulate Failure Scenarios
+        if: ${{ matrix.action == 'install' }}
+        shell: ${{ startsWith(matrix.os, 'windows') && 'pwsh' || 'bash' }}
+        run: |
+          # Fail download step intentionally
+          echo "Testing download failure scenario"
+          exit 1  # Simulate download failure
+
+      - name: Simulate Report Command Failure
+        if: ${{ matrix.action == 'report' }}
+        shell: ${{ startsWith(matrix.os, 'windows') && 'pwsh' || 'bash' }}
+        run: |
+          echo "Testing report command failure"
+          ~/bin/coveralls report  # Simulated failure
+
+      - name: Simulate Done Command Failure
+        if: ${{ matrix.action == 'done' }}
+        shell: ${{ startsWith(matrix.os, 'windows') && 'pwsh' || 'bash' }}
+        run: |
+          echo "Testing done command failure"
+          ~/bin/coveralls done  # Simulated failure
+
+      - name: Verify Outcome
+        shell: ${{ startsWith(matrix.os, 'windows') && 'pwsh' || 'bash' }}
+        run: |
+          if [[ "${{ matrix.fail_on_error }}" == "true" ]]; then
+            # Expect failure exit code
+            if [[ $? -eq 0 ]]; then
+              echo "Test failed: expected failure but action succeeded."
+              exit 1
+            else
+              echo "Test succeeded: expected failure and action failed as expected."
+            fi
+          else
+            # Expect success exit code
+            if [[ $? -ne 0 ]]; then
+              echo "Test failed: expected success but action failed."
+              exit 1
+            else
+              echo "Test succeeded: expected success and action succeeded."
+            fi
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,17 +20,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up environment
+      - name: Set up environment (Linux)
         if: ${{ matrix.os == 'ubuntu-latest' }}
         shell: bash
         run: |
           echo "Running on Linux"
-      - name: Set up environment
+      - name: Set up environment (MacOS)
         if: ${{ matrix.os == 'macos-latest' }}
         shell: bash
         run: |
           echo "Running on macOS"
-      - name: Set up environment
+      - name: Set up environment (Windows)
         if: ${{ matrix.os == 'windows-latest' }}
         shell: pwsh
         run: |
@@ -45,45 +45,45 @@ jobs:
         env:
           CI: true
 
-      # - name: Simulate Failure Scenarios
-      #   if: ${{ matrix.action == 'install' }}
-      #   shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
-      #   run: |
-      #     # Fail download step intentionally
-      #     echo "Testing download failure scenario"
-      #     exit 1  # Simulate download failure
+      - name: Simulate Failure Scenarios
+        if: ${{ matrix.action == 'install' }}
+        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
+        run: |
+          # Fail download step intentionally
+          echo "Testing download failure scenario"
+          exit 1  # Simulate download failure
 
-      # - name: Simulate Report Command Failure
-      #   if: ${{ matrix.action == 'report' }}
-      #   shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
-      #   run: |
-      #     echo "Testing report command failure"
-      #     ~/bin/coveralls report  # Simulated failure
+      - name: Simulate Report Command Failure
+        if: ${{ matrix.action == 'report' }}
+        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
+        run: |
+          echo "Testing report command failure"
+          ~/bin/coveralls report  # Simulated failure
 
-      # - name: Simulate Done Command Failure
-      #   if: ${{ matrix.action == 'done' }}
-      #   shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
-      #   run: |
-      #     echo "Testing done command failure"
-      #     ~/bin/coveralls done  # Simulated failure
+      - name: Simulate Done Command Failure
+        if: ${{ matrix.action == 'done' }}
+        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
+        run: |
+          echo "Testing done command failure"
+          ~/bin/coveralls done  # Simulated failure
 
-      # - name: Verify Outcome
-      #   shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
-      #   run: |
-      #     if [[ "${{ matrix.fail_on_error }}" == "true" ]]; then
-      #       # Expect failure exit code
-      #       if [[ $? -eq 0 ]]; then
-      #         echo "Test failed: expected failure but action succeeded."
-      #         exit 1
-      #       else
-      #         echo "Test succeeded: expected failure and action failed as expected."
-      #       fi
-      #     else
-      #       # Expect success exit code
-      #       if [[ $? -ne 0 ]]; then
-      #         echo "Test failed: expected success but action failed."
-      #         exit 1
-      #       else
-      #         echo "Test succeeded: expected success and action succeeded."
-      #       fi
-      #     fi
+      - name: Verify Outcome
+        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
+        run: |
+          if [[ "${{ matrix.fail_on_error }}" == "true" ]]; then
+            # Expect failure exit code
+            if [[ $? -eq 0 ]]; then
+              echo "Test failed: expected failure but action succeeded."
+              exit 1
+            else
+              echo "Test succeeded: expected failure and action failed as expected."
+            fi
+          else
+            # Expect success exit code
+            if [[ $? -ne 0 ]]; then
+              echo "Test failed: expected success but action failed."
+              exit 1
+            else
+              echo "Test succeeded: expected success and action succeeded."
+            fi
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,45 +45,45 @@ jobs:
         env:
           CI: true
 
-      - name: Simulate Failure Scenarios
-        if: ${{ matrix.action == 'install' }}
-        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
-        run: |
-          # Fail download step intentionally
-          echo "Testing download failure scenario"
-          exit 1  # Simulate download failure
+      # - name: Simulate Failure Scenarios
+      #   if: ${{ matrix.action == 'install' }}
+      #   shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
+      #   run: |
+      #     # Fail download step intentionally
+      #     echo "Testing download failure scenario"
+      #     exit 1  # Simulate download failure
 
-      - name: Simulate Report Command Failure
-        if: ${{ matrix.action == 'report' }}
-        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
-        run: |
-          echo "Testing report command failure"
-          ~/bin/coveralls report  # Simulated failure
+      # - name: Simulate Report Command Failure
+      #   if: ${{ matrix.action == 'report' }}
+      #   shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
+      #   run: |
+      #     echo "Testing report command failure"
+      #     ~/bin/coveralls report  # Simulated failure
 
-      - name: Simulate Done Command Failure
-        if: ${{ matrix.action == 'done' }}
-        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
-        run: |
-          echo "Testing done command failure"
-          ~/bin/coveralls done  # Simulated failure
+      # - name: Simulate Done Command Failure
+      #   if: ${{ matrix.action == 'done' }}
+      #   shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
+      #   run: |
+      #     echo "Testing done command failure"
+      #     ~/bin/coveralls done  # Simulated failure
 
-      - name: Verify Outcome
-        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
-        run: |
-          if [[ "${{ matrix.fail_on_error }}" == "true" ]]; then
-            # Expect failure exit code
-            if [[ $? -eq 0 ]]; then
-              echo "Test failed: expected failure but action succeeded."
-              exit 1
-            else
-              echo "Test succeeded: expected failure and action failed as expected."
-            fi
-          else
-            # Expect success exit code
-            if [[ $? -ne 0 ]]; then
-              echo "Test failed: expected success but action failed."
-              exit 1
-            else
-              echo "Test succeeded: expected success and action succeeded."
-            fi
-          fi
+      # - name: Verify Outcome
+      #   shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
+      #   run: |
+      #     if [[ "${{ matrix.fail_on_error }}" == "true" ]]; then
+      #       # Expect failure exit code
+      #       if [[ $? -eq 0 ]]; then
+      #         echo "Test failed: expected failure but action succeeded."
+      #         exit 1
+      #       else
+      #         echo "Test succeeded: expected failure and action failed as expected."
+      #       fi
+      #     else
+      #       # Expect success exit code
+      #       if [[ $? -ne 0 ]]; then
+      #         echo "Test failed: expected success but action failed."
+      #         exit 1
+      #       else
+      #         echo "Test succeeded: expected success and action succeeded."
+      #       fi
+      #     fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,28 +47,27 @@ jobs:
 
       - name: Simulate Failure Scenarios
         if: ${{ matrix.action == 'install' }}
-        shell: ${{ startsWith(matrix.os, 'windows') && 'pwsh' || 'bash' }}
         run: |
           # Fail download step intentionally
           echo "Testing download failure scenario"
           exit 1  # Simulate download failure
+        shell: ${{ matrix.os == 'windows-latest' && 'pwsh' || 'bash' }}
 
       - name: Simulate Report Command Failure
         if: ${{ matrix.action == 'report' }}
-        shell: ${{ startsWith(matrix.os, 'windows') && 'pwsh' || 'bash' }}
         run: |
           echo "Testing report command failure"
           ~/bin/coveralls report  # Simulated failure
+        shell: ${{ matrix.os == 'windows-latest' && 'pwsh' || 'bash' }}
 
       - name: Simulate Done Command Failure
         if: ${{ matrix.action == 'done' }}
-        shell: ${{ startsWith(matrix.os, 'windows') && 'pwsh' || 'bash' }}
         run: |
           echo "Testing done command failure"
           ~/bin/coveralls done  # Simulated failure
+        shell: ${{ matrix.os == 'windows-latest' && 'pwsh' || 'bash' }}
 
       - name: Verify Outcome
-        shell: ${{ startsWith(matrix.os, 'windows') && 'pwsh' || 'bash' }}
         run: |
           if [[ "${{ matrix.fail_on_error }}" == "true" ]]; then
             # Expect failure exit code
@@ -86,4 +85,5 @@ jobs:
             else
               echo "Test succeeded: expected success and action succeeded."
             fi
-          fi
+        shell: ${{ matrix.os == 'windows-latest' && 'pwsh' || 'bash' }}
+        

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,17 +21,17 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up environment
-        if: matrix.os == 'ubuntu-latest'
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         shell: bash
         run: |
           echo "Running on Linux"
       - name: Set up environment
-        if: matrix.os == 'macos-latest'
+        if: ${{ matrix.os == 'macos-latest' }}
         shell: bash
         run: |
           echo "Running on macOS"
       - name: Set up environment
-        if: matrix.os == 'windows-latest'
+        if: ${{ matrix.os == 'windows-latest' }}
         shell: pwsh
         run: |
           echo "Running on Windows"
@@ -47,27 +47,28 @@ jobs:
 
       - name: Simulate Failure Scenarios
         if: ${{ matrix.action == 'install' }}
+        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
         run: |
           # Fail download step intentionally
           echo "Testing download failure scenario"
           exit 1  # Simulate download failure
-        shell: ${{ matrix.os == 'windows-latest' && 'pwsh' || 'bash' }}
 
       - name: Simulate Report Command Failure
         if: ${{ matrix.action == 'report' }}
+        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
         run: |
           echo "Testing report command failure"
           ~/bin/coveralls report  # Simulated failure
-        shell: ${{ matrix.os == 'windows-latest' && 'pwsh' || 'bash' }}
 
       - name: Simulate Done Command Failure
         if: ${{ matrix.action == 'done' }}
+        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
         run: |
           echo "Testing done command failure"
           ~/bin/coveralls done  # Simulated failure
-        shell: ${{ matrix.os == 'windows-latest' && 'pwsh' || 'bash' }}
 
       - name: Verify Outcome
+        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
         run: |
           if [[ "${{ matrix.fail_on_error }}" == "true" ]]; then
             # Expect failure exit code
@@ -85,5 +86,4 @@ jobs:
             else
               echo "Test succeeded: expected success and action succeeded."
             fi
-        shell: ${{ matrix.os == 'windows-latest' && 'pwsh' || 'bash' }}
-        
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
           debug: true
         env:
           CI: true
+        continue-on-error: ${{ matrix.fail_on_error }}
 
       # - name: Simulate Failure Scenarios
       #   if: ${{ matrix.action == 'install' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        action: [install, report, done]
+        action: [report, done]  # Note: We're also testing 'install' since it's implicitly in each of these two actions
         fail_on_error: [true, false]
     steps:
       - name: Checkout code
@@ -42,49 +42,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-error: ${{ matrix.fail_on_error }}
           debug: true
+          parallel-finished: ${{ matrix.action == 'done' }}  # Only set 'parallel-finished' to true when testing 'done'
         env:
           CI: true
         continue-on-error: ${{ matrix.fail_on_error }}
-
-      # - name: Simulate Failure Scenarios
-      #   if: ${{ matrix.action == 'install' }}
-      #   shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
-      #   run: |
-      #     # Fail download step intentionally
-      #     echo "Testing download failure scenario"
-      #     exit 1  # Simulate download failure
-
-      # - name: Simulate Report Command Failure
-      #   if: ${{ matrix.action == 'report' }}
-      #   shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
-      #   run: |
-      #     echo "Testing report command failure"
-      #     ~/bin/coveralls report  # Simulated failure
-
-      # - name: Simulate Done Command Failure
-      #   if: ${{ matrix.action == 'done' }}
-      #   shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
-      #   run: |
-      #     echo "Testing done command failure"
-      #     ~/bin/coveralls done  # Simulated failure
-
-      # - name: Verify Outcome
-      #   shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
-      #   run: |
-      #     if [[ "${{ matrix.fail_on_error }}" == "true" ]]; then
-      #       # Expect failure exit code
-      #       if [[ $? -eq 0 ]]; then
-      #         echo "Test failed: expected failure but action succeeded."
-      #         exit 1
-      #       else
-      #         echo "Test succeeded: expected failure and action failed as expected."
-      #       fi
-      #     else
-      #       # Expect success exit code
-      #       if [[ $? -ne 0 ]]; then
-      #         echo "Test failed: expected success but action failed."
-      #         exit 1
-      #       else
-      #         echo "Test succeeded: expected success and action succeeded."
-      #       fi
-      #     fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test GitHub Action
+name: Test Modified GitHub Action Steps
 
 on:
   push:
@@ -9,81 +9,63 @@ on:
       - main
 
 jobs:
-  test-action:
-    runs-on: ${{ matrix.os }}
+  test-modified-steps:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        action: [install, report, done]
+        step: [download, report, done]
         fail_on_error: [true, false]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Set up environment
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+      # Test Download & Verification Step
+      - name: Test Download & Verification
+        if: ${{ matrix.step == 'download' }}
         shell: bash
         run: |
-          echo "Running on Linux"
-      - name: Set up environment
-        if: ${{ matrix.os == 'macos-latest' }}
-        shell: bash
-        run: |
-          echo "Running on macOS"
-      - name: Set up environment
-        if: ${{ matrix.os == 'windows-latest' }}
-        shell: pwsh
-        run: |
-          echo "Running on Windows"
+          echo "Testing Download & Verification"
+          asset_path="latest/download"
 
-      - name: Run Test Action
-        uses: ./
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          fail-on-error: ${{ matrix.fail_on_error }}
-          debug: true
-        env:
-          CI: true
-
-      - name: Simulate Failure Scenarios
-        if: ${{ matrix.action == 'install' }}
-        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
-        run: |
-          # Fail download step intentionally
-          echo "Testing download failure scenario"
-          exit 1  # Simulate download failure
-
-      - name: Simulate Report Command Failure
-        if: ${{ matrix.action == 'report' }}
-        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
-        run: |
-          echo "Testing report command failure"
-          ~/bin/coveralls report  # Simulated failure
-
-      - name: Simulate Done Command Failure
-        if: ${{ matrix.action == 'done' }}
-        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
-        run: |
-          echo "Testing done command failure"
-          ~/bin/coveralls done  # Simulated failure
-
-      - name: Verify Outcome
-        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
-        run: |
-          if [[ "${{ matrix.fail_on_error }}" == "true" ]]; then
-            # Expect failure exit code
-            if [[ $? -eq 0 ]]; then
-              echo "Test failed: expected failure but action succeeded."
-              exit 1
-            else
-              echo "Test succeeded: expected failure and action failed as expected."
-            fi
-          else
-            # Expect success exit code
-            if [[ $? -ne 0 ]]; then
-              echo "Test failed: expected success but action failed."
-              exit 1
-            else
-              echo "Test succeeded: expected success and action succeeded."
-            fi
+          # Simulate download and verification failure scenario
+          if ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-linux.tar.gz" ||
+             ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-checksums.txt" ||
+             ! grep coveralls-linux.tar.gz coveralls-checksums.txt | sha256sum --check; then
+            echo "Download or verification failed."
+            if [ "${{ matrix.fail_on_error }}" == "false" ]; then exit 0; else exit 1; fi
           fi
+          echo "Download & verification succeeded."
+
+      # Test Coveralls Report Step
+      - name: Test Coveralls Report
+        if: ${{ matrix.step == 'report' }}
+        shell: bash
+        run: |
+          echo "Testing Coveralls Report Step"
+          if [ ! -f ~/bin/coveralls ]; then
+            echo "Coveralls binary not found."
+            if [ "${{ matrix.fail_on_error }}" == "false" ]; then exit 0; else exit 1; fi
+          fi
+          # Simulate coveralls report execution
+          ~/bin/coveralls report || {
+            echo "Coveralls report failed."
+            if [ "${{ matrix.fail_on_error }}" == "false" ]; then exit 0; else exit 1; fi
+          }
+          echo "Coveralls report succeeded."
+
+      # Test Coveralls Done Step
+      - name: Test Coveralls Done
+        if: ${{ matrix.step == 'done' }}
+        shell: bash
+        run: |
+          echo "Testing Coveralls Done Step"
+          if [ ! -f ~/bin/coveralls ]; then
+            echo "Coveralls binary not found."
+            if [ "${{ matrix.fail_on_error }}" == "false" ]; then exit 0; else exit 1; fi
+          fi
+          # Simulate coveralls done execution
+          ~/bin/coveralls done || {
+            echo "Coveralls done failed."
+            if [ "${{ matrix.fail_on_error }}" == "false" ]; then exit 0; else exit 1; fi
+          }
+          echo "Coveralls done succeeded."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test Modified GitHub Action Steps
+name: Test GitHub Action
 
 on:
   push:
@@ -9,63 +9,81 @@ on:
       - main
 
 jobs:
-  test-modified-steps:
-    runs-on: ubuntu-latest
+  test-action:
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        step: [download, report, done]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        action: [install, report, done]
         fail_on_error: [true, false]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      # Test Download & Verification Step
-      - name: Test Download & Verification
-        if: ${{ matrix.step == 'download' }}
+      - name: Set up environment
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         shell: bash
         run: |
-          echo "Testing Download & Verification"
-          asset_path="latest/download"
-
-          # Simulate download and verification failure scenario
-          if ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-linux.tar.gz" ||
-             ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-checksums.txt" ||
-             ! grep coveralls-linux.tar.gz coveralls-checksums.txt | sha256sum --check; then
-            echo "Download or verification failed."
-            if [ "${{ matrix.fail_on_error }}" == "false" ]; then exit 0; else exit 1; fi
-          fi
-          echo "Download & verification succeeded."
-
-      # Test Coveralls Report Step
-      - name: Test Coveralls Report
-        if: ${{ matrix.step == 'report' }}
+          echo "Running on Linux"
+      - name: Set up environment
+        if: ${{ matrix.os == 'macos-latest' }}
         shell: bash
         run: |
-          echo "Testing Coveralls Report Step"
-          if [ ! -f ~/bin/coveralls ]; then
-            echo "Coveralls binary not found."
-            if [ "${{ matrix.fail_on_error }}" == "false" ]; then exit 0; else exit 1; fi
-          fi
-          # Simulate coveralls report execution
-          ~/bin/coveralls report || {
-            echo "Coveralls report failed."
-            if [ "${{ matrix.fail_on_error }}" == "false" ]; then exit 0; else exit 1; fi
-          }
-          echo "Coveralls report succeeded."
-
-      # Test Coveralls Done Step
-      - name: Test Coveralls Done
-        if: ${{ matrix.step == 'done' }}
-        shell: bash
+          echo "Running on macOS"
+      - name: Set up environment
+        if: ${{ matrix.os == 'windows-latest' }}
+        shell: pwsh
         run: |
-          echo "Testing Coveralls Done Step"
-          if [ ! -f ~/bin/coveralls ]; then
-            echo "Coveralls binary not found."
-            if [ "${{ matrix.fail_on_error }}" == "false" ]; then exit 0; else exit 1; fi
+          echo "Running on Windows"
+
+      - name: Run Test Action
+        uses: ./
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-error: ${{ matrix.fail_on_error }}
+          debug: true
+        env:
+          CI: true
+
+      - name: Simulate Failure Scenarios
+        if: ${{ matrix.action == 'install' }}
+        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
+        run: |
+          # Fail download step intentionally
+          echo "Testing download failure scenario"
+          exit 1  # Simulate download failure
+
+      - name: Simulate Report Command Failure
+        if: ${{ matrix.action == 'report' }}
+        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
+        run: |
+          echo "Testing report command failure"
+          ~/bin/coveralls report  # Simulated failure
+
+      - name: Simulate Done Command Failure
+        if: ${{ matrix.action == 'done' }}
+        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
+        run: |
+          echo "Testing done command failure"
+          ~/bin/coveralls done  # Simulated failure
+
+      - name: Verify Outcome
+        shell: ${{ startsWith(matrix.os, 'windows-latest') && 'pwsh' || 'bash' }}
+        run: |
+          if [[ "${{ matrix.fail_on_error }}" == "true" ]]; then
+            # Expect failure exit code
+            if [[ $? -eq 0 ]]; then
+              echo "Test failed: expected failure but action succeeded."
+              exit 1
+            else
+              echo "Test succeeded: expected failure and action failed as expected."
+            fi
+          else
+            # Expect success exit code
+            if [[ $? -ne 0 ]]; then
+              echo "Test failed: expected success but action failed."
+              exit 1
+            else
+              echo "Test succeeded: expected success and action succeeded."
+            fi
           fi
-          # Simulate coveralls done execution
-          ~/bin/coveralls done || {
-            echo "Coveralls done failed."
-            if [ "${{ matrix.fail_on_error }}" == "false" ]; then exit 0; else exit 1; fi
-          }
-          echo "Coveralls done succeeded."

--- a/action.yml
+++ b/action.yml
@@ -98,28 +98,44 @@ runs:
       run: |
         mkdir -p ~/bin/
         cd ~/bin/
-        if [ $COVERAGE_REPORTER_VERSION == "latest" ]
-        then
-          asset_path=latest/download
+        
+        if [ "$COVERAGE_REPORTER_VERSION" == "latest" ]; then
+          asset_path="latest/download"
         else
           asset_path="download/${COVERAGE_REPORTER_VERSION}"
         fi
+
+        # Debugging output to verify asset path
+        echo "Using asset path: $asset_path"
+
         # Try to download the binary and checksum file
         if ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-linux.tar.gz" ||
-           ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-checksums.txt"; then
+          ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-checksums.txt"; then
           echo "Failed to download coveralls binary or checksum."
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1
         fi
+
+        # List files to ensure they are downloaded
+        echo "Downloaded files:"
+        ls -la
+
         # Verify the downloaded binary
         if ! grep coveralls-linux.tar.gz coveralls-checksums.txt | sha256sum --check; then
           echo "Checksum verification failed."
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1
         fi
-        tar -xzf coveralls-linux.tar.gz
-        rm coveralls-checksums.txt
-        echo ~/bin >> $GITHUB_PATH
+
+    # Extract the tar.gz file
+    tar -xzf coveralls-linux.tar.gz
+
+    # List files again to verify extraction
+    echo "Files after extraction:"
+    ls -la
+
+    rm coveralls-checksums.txt
+    echo ~/bin >> $GITHUB_PATH
 
     - name: Install coveralls reporter (Windows)
       if: startsWith(runner.os, 'Windows')

--- a/action.yml
+++ b/action.yml
@@ -86,14 +86,6 @@ runs:
         brew tap coverallsapp/coveralls --quiet
         brew install coveralls --quiet
 
-        # Debugging output to see where Homebrew installs coveralls
-        echo "Homebrew bin directory:"
-        echo $(brew --prefix)/bin
-
-        # List files in the Homebrew bin directory
-        echo "Listing files in $(brew --prefix)/bin:"
-        ls -la $(brew --prefix)/bin
-
         # Check if the binary exists in the possible locations
         if [ -f /usr/local/bin/coveralls ]; then
           echo "/usr/local/bin" >> $GITHUB_PATH
@@ -140,12 +132,6 @@ runs:
           exit 1
         fi
 
-        # List files to ensure they are downloaded
-        echo "Show current directory:"
-        pwd
-        echo "Downloaded files:"
-        ls -la
-
         # Verify the downloaded binary
         if ! grep coveralls-linux.tar.gz coveralls-checksums.txt | sha256sum --check; then
           echo "Checksum verification failed (Linux)."
@@ -155,12 +141,6 @@ runs:
 
         # Extract the tar.gz file
         tar -xzf coveralls-linux.tar.gz
-
-        # List files again to verify extraction
-        echo "Show current directory:"
-        pwd
-        echo "Files after extraction:"
-        ls -la
 
         rm coveralls-checksums.txt
         echo ~/bin >> $GITHUB_PATH
@@ -178,7 +158,7 @@ runs:
       shell: pwsh
       run: |
         if ("${{ inputs.debug }}" -eq "true") {
-          $DebugPreference = 'Continue'
+          Set-PSDebug -Trace 1
         }
         
         New-Item -Path $env:HOME\bin -ItemType directory -Force

--- a/action.yml
+++ b/action.yml
@@ -143,15 +143,15 @@ runs:
     - name: Done report
       if: inputs.parallel-finished == 'true'
       shell: ${{ startsWith(runner.os, 'Windows') && 'pwsh' || 'bash' }}
-      run: >-
+      run: |
         if [ ! -f coveralls ]; then
           echo "Coveralls binary not found."
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1
-        fi \
-        coveralls done
-        ${{ inputs.debug == 'true' && '--debug' || '' }}
-        ${{ inputs.measure == 'true' && '--measure' || '' }}
+        fi
+        ~/bin/coveralls done \
+        ${{ inputs.debug == 'true' && '--debug' || '' }} \
+        ${{ inputs.measure == 'true' && '--measure' || '' }} \
         ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }}
       env:
         COVERALLS_DEBUG: ${{ inputs.debug }}
@@ -166,20 +166,20 @@ runs:
     - name: Coverage report
       if: inputs.parallel-finished != 'true'
       shell: ${{ startsWith(runner.os, 'Windows') && 'pwsh' || 'bash' }}
-      run: >-
+      run: |
         if [ ! -f coveralls ]; then
           echo "Coveralls binary not found."
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1
-        fi \
-        coveralls report
-        ${{ inputs.debug == 'true' && '--debug' || '' }}
-        ${{ inputs.measure == 'true' && '--measure' || '' }}
-        ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }}
-        ${{ inputs.allow-empty == 'true' && '--allow-empty' || '' }}
-        ${{ inputs.base-path && format('--base-path {0}', inputs.base-path) || '' }}
-        ${{ inputs.format && format('--format {0}', inputs.format) || '' }}
-        ${{ inputs.file || inputs.path-to-lcov }}
+        fi
+        ~/bin/coveralls report \
+        ${{ inputs.debug == 'true' && '--debug' || '' }} \
+        ${{ inputs.measure == 'true' && '--measure' || '' }} \
+        ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }} \
+        ${{ inputs.allow-empty == 'true' && '--allow-empty' || '' }} \
+        ${{ inputs.base-path && format('--base-path {0}', inputs.base-path) || '' }} \
+        ${{ inputs.format && format('--format {0}', inputs.format) || '' }} \
+        ${{ inputs.file || inputs.path-to-lcov }} \
         ${{ inputs.files }}
       env:
         COVERALLS_DEBUG: ${{ inputs.debug }}

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,7 @@
 # action.yml
 name: 'Coveralls GitHub Action'
 description: 'Send test coverage data to Coveralls.io for analysis, change tracking, and notifications.'
-author: 'Nick Merwin (Coveralls, Inc.)'
-inputs:
+author: Coveralls.io
   github-token:
     description: 'Put secrets.GITHUB_TOKEN here'
     required: false
@@ -80,6 +79,9 @@ runs:
       if: runner.os == 'macOS'
       shell: bash
       run: |
+        # Enable debugging if 'debug' is true
+        [ "${{ inputs.debug }}" == "true" ] && set -x
+        
         brew tap coverallsapp/coveralls --quiet
         brew install coveralls --quiet
 
@@ -114,6 +116,9 @@ runs:
         COVERAGE_REPORTER_VERSION: ${{ inputs.coverage-reporter-version }}
       shell: bash
       run: |
+        # Enable debugging if 'debug' is true
+        [ "${{ inputs.debug }}" == "true" ] && set -x
+
         mkdir -p ~/bin/
         cd ~/bin/
 
@@ -171,6 +176,11 @@ runs:
         COVERAGE_REPORTER_VERSION: ${{ inputs.coverage-reporter-version }}
       shell: pwsh
       run: |
+        # Enable debugging if 'debug' is true
+        if ("${{ inputs.debug }}" -eq "true") {
+          $DebugPreference = 'Continue'
+        }
+        
         New-Item -Path $env:HOME\bin -ItemType directory -Force
         Push-Location $env:HOME\bin
         if($env:COVERAGE_REPORTER_VERSION -eq "latest") {

--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ runs:
       run: |
         mkdir -p ~/bin/
         cd ~/bin/
-        if [ $COVERAGE_REPORTER_VERSION == "latest" ]
+        if [ $COVERAGE_REPORTER_VERSION = "latest" ]
         then
           asset_path=latest/download
         else
@@ -114,7 +114,7 @@ runs:
         # Verify the downloaded binary
         if ! grep coveralls-linux.tar.gz coveralls-checksums.txt | sha256sum --check; then
           echo "Checksum verification failed."
-          [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
+          [ "${{ inputs.fail-on-error }}" = "false" ] && exit 0
           exit 1
         fi
         tar -xzf coveralls-linux.tar.gz

--- a/action.yml
+++ b/action.yml
@@ -83,6 +83,7 @@ runs:
         # Enable debugging if 'debug' is true
         [ "${{ inputs.debug }}" == "true" ] && set -x
         
+        # Try to install coverage-reporter via Homebrew
         brew tap coverallsapp/coveralls --quiet
         brew install coveralls --quiet
 
@@ -115,14 +116,12 @@ runs:
         mkdir -p ~/bin/
         cd ~/bin/
 
+        # Determine which version of coverage-reporter to download
         if [ "$COVERAGE_REPORTER_VERSION" == "latest" ]; then
           asset_path="latest/download"
         else
           asset_path="download/${COVERAGE_REPORTER_VERSION}"
         fi
-
-        # Debugging output to verify asset path
-        echo "Using asset path: $asset_path"
 
         # Try to download the binary and checksum file
         if ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-linux.tar.gz" ||
@@ -132,18 +131,14 @@ runs:
           exit 1
         fi
 
-        # Verify the downloaded binary
+        # Try to verify the downloaded binary
         if ! grep coveralls-linux.tar.gz coveralls-checksums.txt | sha256sum --check; then
           echo "Checksum verification failed (Linux)."
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1
         fi
 
-        # Extract the tar.gz file
         tar -xzf coveralls-linux.tar.gz
-
-        rm coveralls-checksums.txt
-        echo ~/bin >> $GITHUB_PATH
 
         # Check if the binary exists
         if [ ! -f ~/bin/coveralls ]; then
@@ -151,16 +146,22 @@ runs:
           exit 1
         fi
 
+        # Cleanup
+        rm coveralls-checksums.txt
+        echo ~/bin >> $GITHUB_PATH
+
     - name: Install coveralls reporter (Windows)
       if: startsWith(runner.os, 'Windows')
       env:
         COVERAGE_REPORTER_VERSION: ${{ inputs.coverage-reporter-version }}
       shell: pwsh
       run: |
+        # Enable debugging if 'debug' is true
         if ("${{ inputs.debug }}" -eq "true") {
           Set-PSDebug -Trace 1
         }
         
+        # Try to download the binary and checksum file
         New-Item -Path $env:HOME\bin -ItemType directory -Force
         Push-Location $env:HOME\bin
         if($env:COVERAGE_REPORTER_VERSION -eq "latest") {
@@ -171,6 +172,7 @@ runs:
           Invoke-WebRequest -Uri "https://github.com/coverallsapp/coverage-reporter/releases/download/$env:COVERAGE_REPORTER_VERSION/coveralls-checksums.txt" -OutFile "sha256sums.txt"
         }
         
+        # Try to verify the downloaded binary
         if ((Get-FileHash coveralls.exe).Hash -ne (Get-Content sha256sums.txt | Select-String 'windows.exe' | ForEach-Object { ($_ -split "\s+")[0] })) {
           Write-Host "Checksum verification failed (Windows)."
           exit 1
@@ -182,6 +184,7 @@ runs:
           exit 1
         }
 
+        # Cleanup
         Remove-Item sha256sums.txt -Force
         echo $env:HOME\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 

--- a/action.yml
+++ b/action.yml
@@ -164,12 +164,12 @@ runs:
       if: inputs.parallel-finished == 'true'
       shell: ${{ startsWith(runner.os, 'Windows') && 'pwsh' || 'bash' }}
       run: |
-        if [ ! -f coveralls ]; then
+        if [ ! -f ~/bin/coveralls ]; then
           echo "Coveralls binary not found."
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1
         fi
-        coveralls done \
+        ~/bin/coveralls done \
         ${{ inputs.debug == 'true' && '--debug' || '' }} \
         ${{ inputs.measure == 'true' && '--measure' || '' }} \
         ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }}
@@ -187,12 +187,12 @@ runs:
       if: inputs.parallel-finished != 'true'
       shell: ${{ startsWith(runner.os, 'Windows') && 'pwsh' || 'bash' }}
       run: |
-        if [ ! -f coveralls ]; then
+        if [ ! -f ~/bin/coveralls ]; then
           echo "Coveralls binary not found."
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1
         fi
-        coveralls report \
+        ~/bin/coveralls report \
         ${{ inputs.debug == 'true' && '--debug' || '' }} \
         ${{ inputs.measure == 'true' && '--measure' || '' }} \
         ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }} \

--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ runs:
       run: |
         mkdir -p ~/bin/
         cd ~/bin/
-        if [ $COVERAGE_REPORTER_VERSION = "latest" ]
+        if [ $COVERAGE_REPORTER_VERSION == "latest" ]
         then
           asset_path=latest/download
         else
@@ -114,7 +114,7 @@ runs:
         # Verify the downloaded binary
         if ! grep coveralls-linux.tar.gz coveralls-checksums.txt | sha256sum --check; then
           echo "Checksum verification failed."
-          [ "${{ inputs.fail-on-error }}" = "false" ] && exit 0
+          [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1
         fi
         tar -xzf coveralls-linux.tar.gz
@@ -148,7 +148,7 @@ runs:
           echo "Coveralls binary not found."
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1
-        fi
+        fi \
         coveralls done
         ${{ inputs.debug == 'true' && '--debug' || '' }}
         ${{ inputs.measure == 'true' && '--measure' || '' }}
@@ -171,7 +171,7 @@ runs:
           echo "Coveralls binary not found."
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1
-        fi
+        fi \
         coveralls report
         ${{ inputs.debug == 'true' && '--debug' || '' }}
         ${{ inputs.measure == 'true' && '--measure' || '' }}

--- a/action.yml
+++ b/action.yml
@@ -144,12 +144,12 @@ runs:
       if: inputs.parallel-finished == 'true'
       shell: ${{ startsWith(runner.os, 'Windows') && 'pwsh' || 'bash' }}
       run: >-
-        if [ ! -f ~/bin/coveralls ]; then
+        if [ ! -f coveralls ]; then
           echo "Coveralls binary not found."
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1
         fi
-        ~/bin/coveralls done
+        coveralls done
         ${{ inputs.debug == 'true' && '--debug' || '' }}
         ${{ inputs.measure == 'true' && '--measure' || '' }}
         ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }}
@@ -167,12 +167,12 @@ runs:
       if: inputs.parallel-finished != 'true'
       shell: ${{ startsWith(runner.os, 'Windows') && 'pwsh' || 'bash' }}
       run: >-
-        if [ ! -f ~/bin/coveralls ]; then
+        if [ ! -f coveralls ]; then
           echo "Coveralls binary not found."
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1
         fi
-        ~/bin/coveralls report
+        coveralls report
         ${{ inputs.debug == 'true' && '--debug' || '' }}
         ${{ inputs.measure == 'true' && '--measure' || '' }}
         ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }}

--- a/action.yml
+++ b/action.yml
@@ -127,13 +127,15 @@ runs:
           exit 1
         fi
 
-    # Extract the tar.gz file
-    tar -xzf coveralls-linux.tar.gz
-    # List files again to verify extraction
-    echo "Files after extraction"
-    ls -la
-    rm coveralls-checksums.txt
-    echo ~/bin >> $GITHUB_PATH
+        # Extract the tar.gz file
+        tar -xzf coveralls-linux.tar.gz
+
+        # List files again to verify extraction
+        echo "Files after extraction:"
+        ls -la
+
+        rm coveralls-checksums.txt
+        echo ~/bin >> $GITHUB_PATH
 
     - name: Install coveralls reporter (Windows)
       if: startsWith(runner.os, 'Windows')

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,7 @@
 name: 'Coveralls GitHub Action'
 description: 'Send test coverage data to Coveralls.io for analysis, change tracking, and notifications.'
 author: Coveralls.io
+inputs:
   github-token:
     description: 'Put secrets.GITHUB_TOKEN here'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -177,7 +177,7 @@ runs:
       shell: pwsh
       run: |
         if ("${{ inputs.debug }}" -eq "true") {
-          Set-PSDebug -Trace 1
+          $DebugPreference = 'Continue'
         }
         
         New-Item -Path $env:HOME\bin -ItemType directory -Force

--- a/action.yml
+++ b/action.yml
@@ -104,9 +104,19 @@ runs:
         else
           asset_path="download/${COVERAGE_REPORTER_VERSION}"
         fi
-        curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-linux.tar.gz"
-        curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-checksums.txt"
-        cat coveralls-checksums.txt | grep coveralls-linux.tar.gz | sha256sum --check
+        # Try to download the binary and checksum file
+        if ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-linux.tar.gz" ||
+           ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-checksums.txt"; then
+          echo "Failed to download coveralls binary or checksum."
+          [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
+          exit 1
+        fi
+        # Verify the downloaded binary
+        if ! grep coveralls-linux.tar.gz coveralls-checksums.txt | sha256sum --check; then
+          echo "Checksum verification failed."
+          [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
+          exit 1
+        fi
         tar -xzf coveralls-linux.tar.gz
         rm coveralls-checksums.txt
         echo ~/bin >> $GITHUB_PATH
@@ -134,7 +144,12 @@ runs:
       if: inputs.parallel-finished == 'true'
       shell: ${{ startsWith(runner.os, 'Windows') && 'pwsh' || 'bash' }}
       run: >-
-        coveralls done
+        if [ ! -f ~/bin/coveralls ]; then
+          echo "Coveralls binary not found."
+          [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
+          exit 1
+        fi
+        ~/bin/coveralls done
         ${{ inputs.debug == 'true' && '--debug' || '' }}
         ${{ inputs.measure == 'true' && '--measure' || '' }}
         ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }}
@@ -152,7 +167,12 @@ runs:
       if: inputs.parallel-finished != 'true'
       shell: ${{ startsWith(runner.os, 'Windows') && 'pwsh' || 'bash' }}
       run: >-
-        coveralls report
+        if [ ! -f ~/bin/coveralls ]; then
+          echo "Coveralls binary not found."
+          [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
+          exit 1
+        fi
+        ~/bin/coveralls report
         ${{ inputs.debug == 'true' && '--debug' || '' }}
         ${{ inputs.measure == 'true' && '--measure' || '' }}
         ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }}

--- a/action.yml
+++ b/action.yml
@@ -83,13 +83,25 @@ runs:
         brew tap coverallsapp/coveralls --quiet
         brew install coveralls --quiet
 
-        # Check if the binary exists in the expected location
-        if [ ! -f /usr/local/bin/coveralls ]; then
+        # Debugging output to see where Homebrew installs coveralls
+        echo "Homebrew bin directory:"
+        echo $(brew --prefix)/bin
+
+        # List files in the Homebrew bin directory
+        echo "Listing files in $(brew --prefix)/bin:"
+        ls -la $(brew --prefix)/bin
+
+        # Check if the binary exists in the possible locations
+        if [ -f /usr/local/bin/coveralls ]; then
+          echo "/usr/local/bin" >> $GITHUB_PATH
+        elif [ -f /opt/homebrew/bin/coveralls ]; then
+          echo "/opt/homebrew/bin" >> $GITHUB_PATH
+        else
           echo "Coveralls binary not found after installation (MacOS)."
           exit 1
         fi
 
-    - name: Report coverage-reporter-version information for macOS
+    - name: Report coverage-reporter-version exception for macOS
       if: ${{ runner.os == 'macOS' && inputs.coverage-reporter-version != 'latest' }}
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -131,6 +131,8 @@ runs:
         tar -xzf coveralls-linux.tar.gz
 
         # List files again to verify extraction
+        echo "List current directory:"
+        pwd
         echo "Files after extraction:"
         ls -la
 

--- a/action.yml
+++ b/action.yml
@@ -117,6 +117,8 @@ runs:
         fi
 
         # List files to ensure they are downloaded
+        echo "Show current directory:"
+        pwd
         echo "Downloaded files:"
         ls -la
 
@@ -131,7 +133,7 @@ runs:
         tar -xzf coveralls-linux.tar.gz
 
         # List files again to verify extraction
-        echo "List current directory:"
+        echo "Show current directory:"
         pwd
         echo "Files after extraction:"
         ls -la
@@ -167,7 +169,7 @@ runs:
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1
         fi
-        ~/bin/coveralls done \
+        coveralls done \
         ${{ inputs.debug == 'true' && '--debug' || '' }} \
         ${{ inputs.measure == 'true' && '--measure' || '' }} \
         ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }}
@@ -190,7 +192,7 @@ runs:
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1
         fi
-        ~/bin/coveralls report \
+        coveralls report \
         ${{ inputs.debug == 'true' && '--debug' || '' }} \
         ${{ inputs.measure == 'true' && '--measure' || '' }} \
         ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }} \

--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ runs:
       run: |
         mkdir -p ~/bin/
         cd ~/bin/
-        
+
         if [ "$COVERAGE_REPORTER_VERSION" == "latest" ]; then
           asset_path="latest/download"
         else
@@ -129,11 +129,9 @@ runs:
 
     # Extract the tar.gz file
     tar -xzf coveralls-linux.tar.gz
-
     # List files again to verify extraction
-    echo "Files after extraction:"
+    echo "Files after extraction"
     ls -la
-
     rm coveralls-checksums.txt
     echo ~/bin >> $GITHUB_PATH
 

--- a/action.yml
+++ b/action.yml
@@ -176,9 +176,8 @@ runs:
         COVERAGE_REPORTER_VERSION: ${{ inputs.coverage-reporter-version }}
       shell: pwsh
       run: |
-        # Enable debugging if 'debug' is true
         if ("${{ inputs.debug }}" -eq "true") {
-          $DebugPreference = 'Continue'
+          Set-PSDebug -Trace 1
         }
         
         New-Item -Path $env:HOME\bin -ItemType directory -Force

--- a/action.yml
+++ b/action.yml
@@ -83,11 +83,17 @@ runs:
         brew tap coverallsapp/coveralls --quiet
         brew install coveralls --quiet
 
+        # Check if the binary exists in the expected location
+        if [ ! -f /usr/local/bin/coveralls ]; then
+          echo "Coveralls binary not found after installation (MacOS)."
+          exit 1
+        fi
+
     - name: Report coverage-reporter-version information for macOS
       if: ${{ runner.os == 'macOS' && inputs.coverage-reporter-version != 'latest' }}
       shell: bash
       run: |
-        echo "The coverage-reporter-version parameter is not available on macOS" >&2
+        echo "The coverage-reporter-version parameter is not available on macOS." >&2
         exit 1
 
     - name: Install coveralls reporter (Linux)
@@ -111,7 +117,7 @@ runs:
         # Try to download the binary and checksum file
         if ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-linux.tar.gz" ||
           ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-checksums.txt"; then
-          echo "Failed to download coveralls binary or checksum."
+          echo "Failed to download coveralls binary or checksum (Linux)."
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1
         fi
@@ -124,7 +130,7 @@ runs:
 
         # Verify the downloaded binary
         if ! grep coveralls-linux.tar.gz coveralls-checksums.txt | sha256sum --check; then
-          echo "Checksum verification failed."
+          echo "Checksum verification failed (Linux)."
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1
         fi
@@ -141,6 +147,12 @@ runs:
         rm coveralls-checksums.txt
         echo ~/bin >> $GITHUB_PATH
 
+        # Check if the binary exists
+        if [ ! -f ~/bin/coveralls ]; then
+          echo "Coveralls binary not found after extraction (Linux)."
+          exit 1
+        fi
+
     - name: Install coveralls reporter (Windows)
       if: startsWith(runner.os, 'Windows')
       env:
@@ -156,22 +168,28 @@ runs:
           Invoke-WebRequest -Uri "https://github.com/coverallsapp/coverage-reporter/releases/download/$env:COVERAGE_REPORTER_VERSION/coveralls-windows.exe" -OutFile "coveralls.exe"
           Invoke-WebRequest -Uri "https://github.com/coverallsapp/coverage-reporter/releases/download/$env:COVERAGE_REPORTER_VERSION/coveralls-checksums.txt" -OutFile "sha256sums.txt"
         }
-        (Get-FileHash coveralls.exe).Hash -eq (Get-Content ./sha256sums.txt | Where-Object{$_ -match 'windows.exe'} | ForEach-Object{($_ -split "\s+")[0]})
-        Remove-Item *.txt -Force
+        
+        if ((Get-FileHash coveralls.exe).Hash -ne (Get-Content sha256sums.txt | Select-String 'windows.exe' | ForEach-Object { ($_ -split "\s+")[0] })) {
+          Write-Host "Checksum verification failed (Windows)."
+          exit 1
+        }
+
+        # Check if the binary exists
+        if (!(Test-Path -Path "$env:HOME\bin\coveralls.exe")) {
+          Write-Host "Coveralls binary not found after download and verification (Windows)."
+          exit 1
+        }
+
+        Remove-Item sha256sums.txt -Force
         echo $env:HOME\bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Done report
       if: inputs.parallel-finished == 'true'
       shell: ${{ startsWith(runner.os, 'Windows') && 'pwsh' || 'bash' }}
-      run: |
-        if [ ! -f ~/bin/coveralls ]; then
-          echo "Coveralls binary not found."
-          [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
-          exit 1
-        fi
-        ~/bin/coveralls done \
-        ${{ inputs.debug == 'true' && '--debug' || '' }} \
-        ${{ inputs.measure == 'true' && '--measure' || '' }} \
+      run: >-
+        coveralls done
+        ${{ inputs.debug == 'true' && '--debug' || '' }}
+        ${{ inputs.measure == 'true' && '--measure' || '' }}
         ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }}
       env:
         COVERALLS_DEBUG: ${{ inputs.debug }}
@@ -186,20 +204,15 @@ runs:
     - name: Coverage report
       if: inputs.parallel-finished != 'true'
       shell: ${{ startsWith(runner.os, 'Windows') && 'pwsh' || 'bash' }}
-      run: |
-        if [ ! -f ~/bin/coveralls ]; then
-          echo "Coveralls binary not found."
-          [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
-          exit 1
-        fi
-        ~/bin/coveralls report \
-        ${{ inputs.debug == 'true' && '--debug' || '' }} \
-        ${{ inputs.measure == 'true' && '--measure' || '' }} \
-        ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }} \
-        ${{ inputs.allow-empty == 'true' && '--allow-empty' || '' }} \
-        ${{ inputs.base-path && format('--base-path {0}', inputs.base-path) || '' }} \
-        ${{ inputs.format && format('--format {0}', inputs.format) || '' }} \
-        ${{ inputs.file || inputs.path-to-lcov }} \
+      run: >-
+        coveralls report
+        ${{ inputs.debug == 'true' && '--debug' || '' }}
+        ${{ inputs.measure == 'true' && '--measure' || '' }}
+        ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }}
+        ${{ inputs.allow-empty == 'true' && '--allow-empty' || '' }}
+        ${{ inputs.base-path && format('--base-path {0}', inputs.base-path) || '' }}
+        ${{ inputs.format && format('--format {0}', inputs.format) || '' }}
+        ${{ inputs.file || inputs.path-to-lcov }}
         ${{ inputs.files }}
       env:
         COVERALLS_DEBUG: ${{ inputs.debug }}


### PR DESCRIPTION
Parallel changes to the orb changes here: https://github.com/coverallsapp/orb/pull/46

## Description

Make sure the `fail-on-error` option's behavior also applies to failures of **setup tasks**, like: 

- Failure to download the binary; 
- Failure to verify the binary; and
- Failure to find the downloaded binary after extraction.

Rather than just to failures of the **coveralls commands**:

- `coveralls report`; or 
- `coveralls done`

### To Do

- [x] Make sure `fail-on-error` behavior applies to any failures downloading, verifying the binary, or finding the binary after download and extraction in the environment
- [x] Enable shell-based debugging in setup steps on each OS, when `debug: true` option is set, so users have insight into setup failures.
- [x] Add a `test.yml` workflow to test the action in a matrix of each OS handled (`ubuntu-latest` | `windows-latest` | `macos-latest`) vs. each possible action (`report` | `done`). 
    - [x] Note: The "setup" tasks are implicitly being tested here because they run in each scenario. And the `debug: true` option will show which step failed on the given platform.