### PR TITLE
Change command flag to be compatible with alpine distros

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -132,7 +132,7 @@ runs:
         fi
 
         # Try to verify the downloaded binary
-        if ! grep coveralls-linux.tar.gz coveralls-checksums.txt | sha256sum --check; then
+        if ! grep coveralls-linux.tar.gz coveralls-checksums.txt | sha256sum -c; then
           echo "Checksum verification failed (Linux)."
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1


### PR DESCRIPTION
Closes #198 

#### :zap: Summary

Change command flag to be compatible with alpine distros.

#### :ballot_box_with_check: Checklist

- [ ] Change `sha256sum --check` command to `sha256sum -c` to be compatible with alpine distros