### PR TITLE
Add build number to supported inputs options

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,3 +46,26 @@ jobs:
         env:
           CI: true
         continue-on-error: ${{ matrix.fail_on_error }}
+
+      - name: Test report with build-number input option
+        if: ${{ matrix.action == 'report' }}
+        uses: ./
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-error: ${{ matrix.fail_on_error }}
+          debug: true
+          build-number: ${{ github.sha }}
+        env:
+          CI: true
+
+      - name: Test done with build-number input option
+        if: ${{ matrix.action == 'done' }}
+        uses: ./
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-error: ${{ matrix.fail_on_error }}
+          debug: true
+          parallel-finished: true
+          build-number: ${{ github.sha }}
+        env:
+          CI: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        action: [report, done, build-number]  # Note: We're also testing 'install' since it's implicit in each action
+        action: [report, done, build-number-report, build-number-done]  # Note: We're also testing 'install' since it's implicit in each action
         fail_on_error: [true, false]
     steps:
       - name: Checkout code
@@ -42,8 +42,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-error: ${{ matrix.fail_on_error }}
           debug: true
-          build-number: ${{ matrix.action == 'build-number' && github.sha || '' }} # Only set 'build-number' to `${{ github.sha }}` when testing `build-number`
-          parallel-finished: ${{ matrix.action == 'done' }}  # Only set `parallel-finished` to `true` when testing `done`
+          build-number: ${{ (matrix.action == 'build-number-report' || matrix.action == 'build-number-done') && github.sha || '' }} # Only set 'build-number' to `${{ github.sha }}` when testing `build-number-report` or `build-number-done`
+          parallel-finished: ${{ matrix.action == 'done' || matrix.action == 'build-number-done' }}  # Only set `parallel-finished` to `true` when testing `done` or `build-number-done`
         env:
           CI: true
         continue-on-error: ${{ matrix.fail_on_error }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        action: [report, done]  # Note: We're also testing 'install' since it's implicitly in each of these two actions
+        action: [report, done, build-number]  # Note: We're also testing 'install' since it's implicit in each action
         fail_on_error: [true, false]
     steps:
       - name: Checkout code
@@ -36,36 +36,14 @@ jobs:
         run: |
           echo "Running on Windows"
 
-      - name: Run Test Action
+      - name: Test Action
         uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           fail-on-error: ${{ matrix.fail_on_error }}
           debug: true
-          parallel-finished: ${{ matrix.action == 'done' }}  # Only set 'parallel-finished' to true when testing 'done'
+          build-number: ${{ matrix.action == 'build-number' && github.sha || '' }} # Only set 'build-number' to `${{ github.sha }}` when testing `build-number`
+          parallel-finished: ${{ matrix.action == 'done' }}  # Only set `parallel-finished` to `true` when testing `done`
         env:
           CI: true
         continue-on-error: ${{ matrix.fail_on_error }}
-
-      - name: Test report with build-number input option
-        if: ${{ matrix.action == 'report' }}
-        uses: ./
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          fail-on-error: ${{ matrix.fail_on_error }}
-          debug: true
-          build-number: ${{ github.sha }}
-        env:
-          CI: true
-
-      - name: Test done with build-number input option
-        if: ${{ matrix.action == 'done' }}
-        uses: ./
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          fail-on-error: ${{ matrix.fail_on_error }}
-          debug: true
-          parallel-finished: true
-          build-number: ${{ github.sha }}
-        env:
-          CI: true

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: 'Job flag name, e.g. "Unit", "Functional", or "Integration". Will be shown in the Coveralls UI.'
     required: false
   build-number:
-    description: 'Override the build number autodetected by CI. This is useful if your CI tool assigns a different build number per parallel build.'
+    description: 'Override the build number autodetected from CI. This is useful if your CI tool assigns a different build number per parallel build.'
     required: false
   parallel:
     description: 'Set to true if you are running parallel jobs, then use "parallel-finished: true" for the last action.'

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     description: 'Job flag name, e.g. "Unit", "Functional", or "Integration". Will be shown in the Coveralls UI.'
     required: false
   build-number:
-    description: 'Override the build number autodetected from CI. This is useful if your CI tool assigns a different build number per parallel build.'
+    description: 'Override the build number autodetected from CI. This is useful if your CI tool assigns a different build number per each parallel build.'
     required: false
   parallel:
     description: 'Set to true if you are running parallel jobs, then use "parallel-finished: true" for the last action.'

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
   flag-name:
     description: 'Job flag name, e.g. "Unit", "Functional", or "Integration". Will be shown in the Coveralls UI.'
     required: false
+  build-number:
+    description: 'Override the build number autodetected by CI. This is useful if your CI tool assigns a different build number per parallel build.'
+    required: false
   parallel:
     description: 'Set to true if you are running parallel jobs, then use "parallel-finished: true" for the last action.'
     required: false
@@ -195,6 +198,7 @@ runs:
         coveralls done
         ${{ inputs.debug == 'true' && '--debug' || '' }}
         ${{ inputs.measure == 'true' && '--measure' || '' }}
+        ${{ inputs.build-number && format('--build-number {0}', inputs.build-number) || '' }}
         ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }}
       env:
         COVERALLS_DEBUG: ${{ inputs.debug }}
@@ -216,6 +220,7 @@ runs:
         ${{ inputs.fail-on-error == 'false' && '--no-fail' || '' }}
         ${{ inputs.allow-empty == 'true' && '--allow-empty' || '' }}
         ${{ inputs.base-path && format('--base-path {0}', inputs.base-path) || '' }}
+        ${{ inputs.build-number && format('--build-number {0}', inputs.build-number) || '' }}
         ${{ inputs.format && format('--format {0}', inputs.format) || '' }}
         ${{ inputs.file || inputs.path-to-lcov }}
         ${{ inputs.files }}


### PR DESCRIPTION
## Description
Let users substitute an alternate **build number** for the _default_ build number: `S{{ github.run_id }} `.

- [x] Add `build-number` to input options and pass it to the binary.
- [ ] Add a test to verify `--build-number` is correctly passed to `coverage-reporter`

## Contributed by

- @brianatgather 🙏 

## Alternative Approach: Coveralls Environment Variables

Please note that substituting key input values, like **build number** (aka. [service_number](https://docs.coveralls.io/api-jobs-endpoint#:~:text=String-,service_number,-The%20build%20number)), so they are passed to the `coverage-reporter` binary from this `github-action`, is always possible through the use of [Coveralls Environment Variables](https://github.com/coverallsapp/coverage-reporter/blob/master/doc/configuration.md#env-variables).

To substitute **build number**, use `COVERALLS_SERVICE_NUMBER` in your step config:

- **Example: commit sha**: - A common alternative to `${{ github.run_id }}` that can be used to tie _several_ GitHub Actions workflows together at Coveralls is **commit sha** (`${{ github.sha }}`), so a configuration like the one below will override the _default_ (_`${{ github.run_id }}`_):

**Parallel upload step**:

```
    - name: Coveralls Parallel Upload
      uses: coverallsapp/github-action@v2
      env:
        COVERALLS_SERVICE_NUMBER: ${{ github.sha }} # default: ${{ github.run_id }}
      with:
        parallel: true
        flag_name: my-flag-name-1
```

In the case of this substitution, make sure you also pass it to the "**Parallel finished**" step, which _requires the **build number**_ to find your build at Coveralls:

**Parallel finished step**:

```
    - name: Coveralls Finished
      uses: coverallsapp/github-action@v2
      env:
        COVERALLS_SERVICE_NUMBER: ${{ github.sha }}
      with:
        parallel-finished: true
        carryforward: "my-flag-name-1,my-flag-name-2"
```