### PR TITLE
Verify that `coverage-reporter-version` option is recognized

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           coverage-reporter-version: ${{ matrix.coverage_reporter_version != '' && matrix.coverage_reporter_version || '' }}
         env:
           CI: true
-        continue-on-error: ${{ matrix.fail_on_error == 'false' }} # Inverse of fail-on-error
+        continue-on-error: true
 
       - name: (Debug) Print coverage-reporter-version
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
           coverage-reporter-version: ${{ matrix.coverage_reporter_version != '' && matrix.coverage_reporter_version || '' }}
         env:
           CI: true
-        continue-on-error: ${{ matrix.fail_on_error }}
+        continue-on-error: ${{ matrix.fail_on_error == 'false' }} # Inverse of fail-on-error
 
       - name: (Debug) Print coverage-reporter-version
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         action: [report, done, build-number-report, build-number-done]  # Note: We're also testing 'install' since it's implicit in each action
         fail_on_error: [true, false]
+        coverage_reporter_version: ['v0.6.14', 'latest', '']
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -40,10 +41,16 @@ jobs:
         uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          fail-on-error: ${{ matrix.fail_on_error }}
           debug: true
+          fail-on-error: ${{ matrix.fail_on_error }}
           build-number: ${{ (matrix.action == 'build-number-report' || matrix.action == 'build-number-done') && github.sha || '' }} # Only set 'build-number' to `${{ github.sha }}` when testing `build-number-report` or `build-number-done`
           parallel-finished: ${{ matrix.action == 'done' || matrix.action == 'build-number-done' }}  # Only set `parallel-finished` to `true` when testing `done` or `build-number-done`
+          coverage-reporter-version: ${{ matrix.coverage_reporter_version != '' && matrix.coverage_reporter_version || '' }}
         env:
           CI: true
         continue-on-error: ${{ matrix.fail_on_error }}
+
+      - name: (Debug) Print coverage-reporter-version
+        run: |
+          echo "coverage-reporter-version: ${{ matrix.coverage_reporter_version }}"
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,8 +49,3 @@ jobs:
         env:
           CI: true
         continue-on-error: true
-
-      - name: (Debug) Print coverage-reporter-version
-        run: |
-          echo "coverage-reporter-version: ${{ matrix.coverage_reporter_version }}"
-

--- a/action.yml
+++ b/action.yml
@@ -120,7 +120,7 @@ runs:
         cd ~/bin/
 
         # Determine which version of coverage-reporter to download
-        if [ "$COVERAGE_REPORTER_VERSION" == "latest" ]; then
+        if [ -z "$COVERAGE_REPORTER_VERSION" ] || [ "$COVERAGE_REPORTER_VERSION" == "latest" ]; then
           asset_path="latest/download"
         else
           asset_path="download/${COVERAGE_REPORTER_VERSION}"
@@ -167,7 +167,7 @@ runs:
         # Try to download the binary and checksum file
         New-Item -Path $env:HOME\bin -ItemType directory -Force
         Push-Location $env:HOME\bin
-        if($env:COVERAGE_REPORTER_VERSION -eq "latest") {
+        if ([string]::IsNullOrEmpty($env:COVERAGE_REPORTER_VERSION) -or $env:COVERAGE_REPORTER_VERSION -eq "latest") {
           Invoke-WebRequest -Uri "https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-windows.exe" -OutFile "coveralls.exe"
           Invoke-WebRequest -Uri "https://github.com/coverallsapp/coverage-reporter/releases/latest/download/coveralls-checksums.txt" -OutFile "sha256sums.txt"
         } else {

--- a/action.yml
+++ b/action.yml
@@ -105,7 +105,11 @@ runs:
       shell: bash
       run: |
         echo "The coverage-reporter-version parameter is not available on macOS." >&2
-        exit 1
+        if [[ "${{ inputs.fail-on-error }}" == "true" ]]; then
+          exit 1
+        else
+          exit 0
+        fi
 
     - name: Install coveralls reporter (Linux)
       if: runner.os == 'Linux'


### PR DESCRIPTION
Fixes #225 

## Description

Verify that `coverage-reporter-version` input option is being recognized.

## To Do

- [x] Add test for `coverage-reporter-version`.
- [x] Modify download logic on `linux` and `windows`: Default to `"latest"` version of `coverage-reporter` when `COVERAGE_REPORTER_VERSION` is `null`_**---or `empty` (`''`)**_ (ie. when `coverage-reporter-version` is unset,_---or set to `''`_.)
- [x] Apply `fail-on-error` behavior to error returned when user tries to set `coverage-reporter-version` on MacOS. (installing a specific version of coverage-reporter, via Homebrew, is not available there.)