### PR TITLE
Add a couple of helpful steps to update-major-version-tag workflow

### DIFF
--- a/.github/workflows/update-major-version-tag.yml
+++ b/.github/workflows/update-major-version-tag.yml
@@ -24,3 +24,9 @@ jobs:
           git fetch --tags
           git tag -f ${{ env.major_version }} ${{ github.event.release.tag_name }}
           git push origin ${{ env.major_version }} --force
+
+      - name: Fetch Updated Tags
+        run: git fetch --tags --force
+      
+      - name: Verify Tag
+        run: git show ${{ env.major_version }}


### PR DESCRIPTION
Follow-up on PR #230 

## Description
Add a couple of steps to `update-major-version-tag.yml` to: 

1. Reset the major version tag on the local runner in case it's needed for subsequent workflow steps anywhere else; and 
2. Display new details on the major version tag to verify it worked as expected and points to the latest release.