### PR TITLE
Add `coverage-reporter-platform` input option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
           build-number: ${{ (matrix.action == 'build-number-report' || matrix.action == 'build-number-done') && github.sha || '' }} # Only set 'build-number' to `${{ github.sha }}` when testing `build-number-report` or `build-number-done`
           parallel-finished: ${{ matrix.action == 'done' || matrix.action == 'build-number-done' }}  # Only set `parallel-finished` to `true` when testing `done` or `build-number-done`
           coverage-reporter-version: ${{ matrix.coverage_reporter_version != '' && matrix.coverage_reporter_version || '' }}
+          coverage-reporter-platform: ${{ matrix.coverage_reporter_platform }}
         env:
           CI: true
         continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,4 +49,4 @@ jobs:
           coverage-reporter-platform: ${{ matrix.coverage_reporter_platform }}
         env:
           CI: true
-        continue-on-error: true
+        # continue-on-error: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,4 +49,4 @@ jobs:
           coverage-reporter-platform: ${{ matrix.coverage_reporter_platform }}
         env:
           CI: true
-        # continue-on-error: true
+        continue-on-error: true

--- a/action.yml
+++ b/action.yml
@@ -145,9 +145,8 @@ runs:
             platform_filename="coveralls-linux-aarch64.tar.gz"
             ;;
           *)
-            echo "Unsupported platform: $COVERAGE_REPORTER_PLATFORM"
-            [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
-            exit 1
+            echo "Warning: Unsupported platform: $COVERAGE_REPORTER_PLATFORM. The default x86_64 version ($version_message) will be used." >&2
+            platform_filename="coveralls-linux-x86_64.tar.gz"
             ;;
         esac
 

--- a/action.yml
+++ b/action.yml
@@ -161,8 +161,32 @@ runs:
         fi
 
         # Try to verify the downloaded binary
-        if ! grep "${platform_filename}" coveralls-checksums.txt | sha256sum -c; then
+        # if ! grep "${platform_filename}" coveralls-checksums.txt | sha256sum -c; then
+        #   echo "Checksum verification failed (Linux)."
+        #   [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
+        #   exit 1
+        # fi
+
+        # Print contents of checksum file for debugging
+        echo "Contents of coveralls-checksums.txt:"
+        cat coveralls-checksums.txt
+
+        # Extract the expected checksum
+        expected_checksum=$(grep "${platform_filename}" coveralls-checksums.txt | awk '{print $1}')
+        if [ -z "$expected_checksum" ]; then
+          echo "Failed to extract checksum for ${platform_filename}"
+          [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
+          exit 1
+        fi
+
+        # Compute the actual checksum
+        actual_checksum=$(sha256sum "${platform_filename}" | awk '{print $1}')
+
+        # Compare checksums
+        if [ "$expected_checksum" != "$actual_checksum" ]; then
           echo "Checksum verification failed (Linux)."
+          echo "Expected: $expected_checksum"
+          echo "Actual: $actual_checksum"
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1
         fi

--- a/action.yml
+++ b/action.yml
@@ -140,7 +140,7 @@ runs:
 
         # Determine the platform-specific filename
         case "$COVERAGE_REPORTER_PLATFORM" in
-          x86_64)
+          x86_64|"")
             platform_filename="coveralls-linux-x86_64.tar.gz"
             ;;
           aarch64|arm64)

--- a/action.yml
+++ b/action.yml
@@ -132,8 +132,10 @@ runs:
         # Determine which version of coverage-reporter to download
         if [ -z "$COVERAGE_REPORTER_VERSION" ] || [ "$COVERAGE_REPORTER_VERSION" == "latest" ]; then
           asset_path="latest/download"
+          version_message="latest"
         else
           asset_path="download/${COVERAGE_REPORTER_VERSION}"
+          version_message="$COVERAGE_REPORTER_VERSION"
         fi
 
         # Determine the platform-specific filename
@@ -165,7 +167,7 @@ runs:
           exit 1
         fi
 
-        tar -xzf coveralls-linux.tar.gz
+        tar -xzf ${platform_filename}
 
         # Check if the binary exists
         if [ ! -f ~/bin/coveralls ]; then

--- a/action.yml
+++ b/action.yml
@@ -138,19 +138,47 @@ runs:
           version_message="$COVERAGE_REPORTER_VERSION"
         fi
 
-        # Determine the platform-specific filename
+        # Function to compare version numbers
+        version_ge() {
+          # Compare two version numbers
+          [ "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1" ]
+        }
+
+        # Determine the platform-specific filename:
+        # This logic is necessary due to the introduction of multiple platform support starting from v0.6.15.
+        # It selects the correct filename based on the specified platform and version, while ensuring
+        # backward compatibility with earlier versions that only supported a generic Linux binary for x86_64.
         case "$COVERAGE_REPORTER_PLATFORM" in
           x86_64|"")
-            platform_filename="coveralls-linux-x86_64.tar.gz"
+            if version_ge "$COVERAGE_REPORTER_VERSION" "v0.6.15"; then
+              platform_filename="coveralls-linux-x86_64.tar.gz"
+            else
+              platform_filename="coveralls-linux.tar.gz"
+            fi
             ;;
           aarch64|arm64)
-            platform_filename="coveralls-linux-aarch64.tar.gz"
+            if version_ge "$COVERAGE_REPORTER_VERSION" "v0.6.15"; then
+              platform_filename="coveralls-linux-aarch64.tar.gz"
+            else
+              echo "Warning: The aarch64/arm64 platform is only supported from version v0.6.15 onwards. Proceeding with v0.6.15." >&2
+              asset_path="download/v0.6.15"
+              platform_filename="coveralls-linux-aarch64.tar.gz"
+            fi
             ;;
           *)
             echo "Warning: Unsupported platform: $COVERAGE_REPORTER_PLATFORM. The default x86_64 version ($version_message) will be used." >&2
-            platform_filename="coveralls-linux-x86_64.tar.gz"
+            if version_ge "$COVERAGE_REPORTER_VERSION" "v0.6.15"; then
+              platform_filename="coveralls-linux-x86_64.tar.gz"
+            else
+              platform_filename="coveralls-linux.tar.gz"
+            fi
             ;;
         esac
+
+        # Checksum verification:
+        # The following code was chosen to replace the more simple `sha256sum -c` because it provides
+        # clearer debugging information around our new matrix of supported coverage-reporter versions and platforms.
+        # We may drop back to `${platform_filename}" coveralls-checksums.txt | sha256sum -c` when we're more confidently handling these.
 
         # Try to download the binary and checksum file
         if ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/${platform_filename}" ||
@@ -160,18 +188,11 @@ runs:
           exit 1
         fi
 
-        # Try to verify the downloaded binary
-        # if ! grep "${platform_filename}" coveralls-checksums.txt | sha256sum -c; then
-        #   echo "Checksum verification failed (Linux)."
-        #   [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
-        #   exit 1
-        # fi
-
-        # Print contents of checksum file for debugging
+        # DEBUG: Print contents of checksum file for debugging
         echo "Contents of coveralls-checksums.txt:"
         cat coveralls-checksums.txt
 
-        # Extract the expected checksum
+        # Extract expected checksum
         expected_checksum=$(grep "${platform_filename}" coveralls-checksums.txt | awk '{print $1}')
         if [ -z "$expected_checksum" ]; then
           echo "Failed to extract checksum for ${platform_filename}"
@@ -179,10 +200,10 @@ runs:
           exit 1
         fi
 
-        # Compute the actual checksum
+        # Compute actual checksum
         actual_checksum=$(sha256sum "${platform_filename}" | awk '{print $1}')
 
-        # Compare checksums
+        # Perform verification by comparing expected and actual checksums
         if [ "$expected_checksum" != "$actual_checksum" ]; then
           echo "Checksum verification failed (Linux)."
           echo "Expected: $expected_checksum"

--- a/action.yml
+++ b/action.yml
@@ -73,12 +73,28 @@ inputs:
     description: "Version of coverage-reporter to use. Make sure to prefix the version number with 'v'. For example: v0.6.9"
     required: false
     default: 'latest'
+  coverage-reporter-platform:
+    description: "Platform of coverage-reporter to use on Linux runners. Supported values: x86_64 (default) and aarch64 (or arm64)"
+    required: false
+    default: 'x86_64'
 branding:
   color: 'green'
   icon: 'percent'
 runs:
   using: 'composite'
   steps:
+    - name: Report coverage-reporter-version exception for macOS
+      if: ${{ runner.os == 'macOS' && inputs.coverage-reporter-version != 'latest' }}
+      shell: bash
+      run: |
+        echo "Warning: The coverage-reporter-version parameter is not available on macOS. The latest version will be installed via Homebrew." >&2
+
+    - name: Report coverage-reporter-platform exception for macOS
+      if: ${{ runner.os == 'macOS' && inputs.coverage-reporter-platform != '' }}
+      shell: bash
+      run: |
+        echo "Warning: The coverage-reporter-platform parameter is not available on macOS. The default version for macOS will be used." >&2
+    
     - name: Install coveralls reporter (macOS)
       if: runner.os == 'macOS'
       shell: bash
@@ -100,21 +116,11 @@ runs:
           exit 1
         fi
 
-    - name: Report coverage-reporter-version exception for macOS
-      if: ${{ runner.os == 'macOS' && inputs.coverage-reporter-version != 'latest' }}
-      shell: bash
-      run: |
-        echo "The coverage-reporter-version parameter is not available on macOS." >&2
-        if [[ "${{ inputs.fail-on-error }}" == "true" ]]; then
-          exit 1
-        else
-          exit 0
-        fi
-
     - name: Install coveralls reporter (Linux)
       if: runner.os == 'Linux'
       env:
         COVERAGE_REPORTER_VERSION: ${{ inputs.coverage-reporter-version }}
+        COVERAGE_REPORTER_PLATFORM: ${{ inputs.coverage-reporter-platform }}
       shell: bash
       run: |
         # Enable debugging if 'debug' is true
@@ -130,8 +136,23 @@ runs:
           asset_path="download/${COVERAGE_REPORTER_VERSION}"
         fi
 
+        # Determine the platform-specific filename
+        case "$COVERAGE_REPORTER_PLATFORM" in
+          x86_64)
+            platform_filename="coveralls-linux-x86_64.tar.gz"
+            ;;
+          aarch64|arm64)
+            platform_filename="coveralls-linux-aarch64.tar.gz"
+            ;;
+          *)
+            echo "Unsupported platform: $COVERAGE_REPORTER_PLATFORM"
+            [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
+            exit 1
+            ;;
+        esac
+
         # Try to download the binary and checksum file
-        if ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-linux.tar.gz" ||
+        if ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/${platform_filename}" ||
           ! curl -sLO "https://github.com/coverallsapp/coverage-reporter/releases/${asset_path}/coveralls-checksums.txt"; then
           echo "Failed to download coveralls binary or checksum (Linux)."
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
@@ -157,6 +178,12 @@ runs:
         rm coveralls-checksums.txt
         echo ~/bin >> $GITHUB_PATH
 
+    - name: Report coverage-reporter-platform exception for Windows
+      if: ${{ startsWith(runner.os, 'Windows') && inputs.coverage-reporter-platform != '' }}
+      shell: pwsh
+      run: |
+        Write-Host "Warning: The coverage-reporter-platform parameter is not available on Windows. The default version for Windows will be used." -ForegroundColor Yellow
+    
     - name: Install coveralls reporter (Windows)
       if: startsWith(runner.os, 'Windows')
       env:

--- a/action.yml
+++ b/action.yml
@@ -161,13 +161,13 @@ runs:
         fi
 
         # Try to verify the downloaded binary
-        if ! grep coveralls-linux.tar.gz coveralls-checksums.txt | sha256sum -c; then
+        if ! grep "${platform_filename}" coveralls-checksums.txt | sha256sum -c; then
           echo "Checksum verification failed (Linux)."
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1
         fi
 
-        tar -xzf ${platform_filename}
+        tar -xzf "${platform_filename}"
 
         # Check if the binary exists
         if [ ! -f ~/bin/coveralls ]; then


### PR DESCRIPTION
Fixes #218 

## Description

Since we have added support for `coverage-reporter` on `aarch64`, we need to provide users of our `github-action` the ability to select this architecture-specific version of `coverage-reporter` when on an `aarch64` / `arm64` runner. 

## To Do

- [x] **New input option** - Add `coverage-reporter-platform` input option to control which architecture-specific version of coverage-reporter is downloaded and run by the github-action. (Linux only.)
- [x] **Exception messages** - Since this option is not available for MacOS or Windows, we will deliver warning messages if the option is set, but continue processing with default behavior. 
    - [x] We have also stepped back from the previous implementation of the exception for `coverage-reporter-version` on MacOS and have turned that error message + exit code 1 into a warning message, allowing processing to proceed. 
- [x] **Tests** - We have also added tests to test different values for `coverage-reporter-platform`.