### PR TITLE
README/Inputs: list all (non-deprecated) inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,27 +12,29 @@ This action's step needs to run after your test suite has outputted a coverage r
 
 ### Inputs:
 
-| Name                        | Requirement | Description |
-| --------------------------- | ----------- | ----------- |
-| `github-token`              | _required_ | Default if not specified: `${{ github.token }}`. Can be also specified this way: `github-token: ${{ secrets.GITHUB_TOKEN }}`; Coveralls uses this token to verify the appropriate repo at Coveralls and send any new status updates based on your coverage results. This variable is built into Github Actions, so __do not add it to your secrets store__. [More Info](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token)|
-| `file`                      | _optional_ | Default: all coverage files that could be found. Local path to the coverage report file produced by your test suite. An error will be thrown if no file was found. This is the file that will be sent to the Coveralls API. Leave empty if you want to combine many files reports. |
-| `files`                     | _optional_ | Default: all coverage files that could be found. Space-separated list of coverage report files produced by your test suite. Example: `files: coverage/test1.lcov coverage/test2.lcov` |
-| `format`                    | _optional_ | Force coverage report format. If not specified, coveralls will try to detect the format based on file extension and/or content. Possible values: `lcov`, `simplecov`, `cobertura`, `jacoco`, `gcov`, `golang`, `python`. See also [supported coverage report formats list](https://github.com/coverallsapp/coverage-reporter#supported-coverage-report-formats). |
-| `flag-name`                 | _optional (unique required if parallel)_ | Job flag name, e.g. "Unit", "Functional", or "Integration". Will be shown in the Coveralls UI. |
-| `parallel`                  | _optional_ | Set to true for parallel (or matrix) based steps, where multiple posts to Coveralls will be performed in the check. `flag-name` needs to be set and unique, e.g. `flag-name: run ${{ join(matrix.*, ' - ') }}` |
-| `parallel-finished`         | _optional_ | Set to true in the last job, after the other parallel jobs steps have completed, this will send a webhook to Coveralls to set the build complete. |
-| `carryforward`              | _optional_ | Comma separated flags used to carryforward results from previous builds if some of the parallel jobs are missing. Used only with `parallel-finished`. |
-| `coveralls-endpoint`        | _optional_ | Hostname and protocol: `https://<host>`; Specifies a [Coveralls Enterprise](https://enterprise.coveralls.io/) hostname. |
-| `allow-empty`               | _optional_ | Default: `false`. Don't fail if coverage report is empty or contains no coverage data. |
-| `base-path`                 | _optional_ | Path to the root folder of the project the coverage was collected in. Should be used in monorepos so that coveralls can process filenames from your coverage reports correctly (e.g. packages/my-subproject) |
-| `git-branch`                | _optional_ | Default: GITHUB_REF environment variable. Override the branch name. |
-| `git-commit`                | _optional_ | Default: GITHUB_SHA environment variable. Override the commit SHA. |
-| `compare-ref`               | _optional_ | Branch name to compare coverage with. Specify if you want to always check coverage change for PRs against one branch. |
-| `compare-sha`               | _optional_ | Commit SHA to compare coverage with. |
-| `debug`                     | _optional_ | Default: `false`. Set to `true` to enable debug logging. |
-| `measure`                   | _optional_ | Default: `false`. Set to `true` to enable time time measurement logging. |
-| `fail-on-error`             | _optional_ | Default: `true`. Set to `false` to avoid CI failure when upload fails due to any errors. |
-| `coverage-reporter-version` | _optional_ | Default: `latest`. Version of coverage-reporter to use. Make sure to prefix the version number with 'v'. For example: v0.6.9. Not available currently on macOS. |
+| Name                         | Requirement | Description |
+| ---------------------------- | ----------- | ----------- |
+| `github-token`               | _required_ | Default if not specified: `${{ github.token }}`. Can be also specified this way: `github-token: ${{ secrets.GITHUB_TOKEN }}`; Coveralls uses this token to verify the appropriate repo at Coveralls and send any new status updates based on your coverage results. This variable is built into Github Actions, so __do not add it to your secrets store__. [More Info](https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token)|
+| `file`                       | _optional_ | Default: all coverage files that could be found. Local path to the coverage report file produced by your test suite. An error will be thrown if no file was found. This is the file that will be sent to the Coveralls API. Leave empty if you want to combine many files reports. |
+| `files`                      | _optional_ | Default: all coverage files that could be found. Space-separated list of coverage report files produced by your test suite. Example: `files: coverage/test1.lcov coverage/test2.lcov` |
+| `format`                     | _optional_ | Force coverage report format. If not specified, coveralls will try to detect the format based on file extension and/or content. Possible values: `lcov`, `simplecov`, `cobertura`, `jacoco`, `gcov`, `golang`, `python`. See also [supported coverage report formats list](https://github.com/coverallsapp/coverage-reporter#supported-coverage-report-formats). |
+| `flag-name`                  | _optional (unique required if parallel)_ | Job flag name, e.g. "Unit", "Functional", or "Integration". Will be shown in the Coveralls UI. |
+| `build-number`               | _optional_ | Default: autodetected from CI. This should be the same for all jobs in a parallel build. Override this is useful if your CI tool assigns a different build number for each parallel build. |
+| `parallel`                   | _optional_ | Set to true for parallel (or matrix) based steps, where multiple posts to Coveralls will be performed in the check. `flag-name` needs to be set and unique, e.g. `flag-name: run ${{ join(matrix.*, ' - ') }}` |
+| `parallel-finished`          | _optional_ | Set to true in the last job, after the other parallel jobs steps have completed, this will send a webhook to Coveralls to set the build complete. |
+| `carryforward`               | _optional_ | Comma separated flags used to carryforward results from previous builds if some of the parallel jobs are missing. Used only with `parallel-finished`. |
+| `coveralls-endpoint`         | _optional_ | Hostname and protocol: `https://<host>`; Specifies a [Coveralls Enterprise](https://enterprise.coveralls.io/) hostname. |
+| `allow-empty`                | _optional_ | Default: `false`. Don't fail if coverage report is empty or contains no coverage data. |
+| `base-path`                  | _optional_ | Path to the root folder of the project the coverage was collected in. Should be used in monorepos so that coveralls can process filenames from your coverage reports correctly (e.g. packages/my-subproject) |
+| `git-branch`                 | _optional_ | Default: GITHUB_REF environment variable. Override the branch name. |
+| `git-commit`                 | _optional_ | Default: GITHUB_SHA environment variable. Override the commit SHA. |
+| `compare-ref`                | _optional_ | Branch name to compare coverage with. Specify if you want to always check coverage change for PRs against one branch. |
+| `compare-sha`                | _optional_ | Commit SHA to compare coverage with. |
+| `debug`                      | _optional_ | Default: `false`. Set to `true` to enable debug logging. |
+| `measure`                    | _optional_ | Default: `false`. Set to `true` to enable time measurement logging. |
+| `fail-on-error`              | _optional_ | Default: `true`. Set to `false` to avoid CI failure when upload fails due to any errors. |
+| `coverage-reporter-version`  | _optional_ | Default: `latest`. Version of coverage-reporter to use. Make sure to prefix the version number with 'v'. For example: v0.6.9. Not available currently on macOS. |
+| `coverage-reporter-platform` | _optional_ | Default: `x86_64`. Platform of coverage-reporter to use on Linux runners. Supported values: x86_64 (default) and aarch64 (or arm64). |
 
 <!-- Leaving this here until we decide whether to bring back `coveralls-api-result` in v2 -->
 <!-- Please submit any questions, suggestions, requests to: support@coveralls.io -->

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This action's step needs to run after your test suite has outputted a coverage r
 | `measure`                    | _optional_ | Default: `false`. Set to `true` to enable time measurement logging. |
 | `fail-on-error`              | _optional_ | Default: `true`. Set to `false` to avoid CI failure when upload fails due to any errors. |
 | `coverage-reporter-version`  | _optional_ | Default: `latest`. Version of coverage-reporter to use. Make sure to prefix the version number with 'v'. For example: v0.6.9. Not available currently on macOS. |
-| `coverage-reporter-platform` | _optional_ | Default: `x86_64`. Platform of coverage-reporter to use on Linux runners. Supported values: x86_64 (default) and aarch64 (or arm64). |
+| `coverage-reporter-platform` | _optional_ | Default: `x86_64`. Platform of coverage-reporter to use on Linux runners. Supported values: `x86_64` (default) and `aarch64` (or `arm64`). |
 
 <!-- Leaving this here until we decide whether to bring back `coveralls-api-result` in v2 -->
 <!-- Please submit any questions, suggestions, requests to: support@coveralls.io -->


### PR DESCRIPTION
A few of the supported inputs were missing, most notably the recently added `coverage-reporter-platform` input (see #233).

Fixed now.

Includes fixing up a grammatical error.