### PR TITLE
Explicitly set auto-detect as default for platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This action's step needs to run after your test suite has outputted a coverage r
 | `measure`                    | _optional_ | Default: `false`. Set to `true` to enable time measurement logging. |
 | `fail-on-error`              | _optional_ | Default: `true`. Set to `false` to avoid CI failure when upload fails due to any errors. |
 | `coverage-reporter-version`  | _optional_ | Default: `latest`. Version of coverage-reporter to use. Make sure to prefix the version number with 'v'. For example: v0.6.9. Not available currently on macOS. |
-| `coverage-reporter-platform` | _optional_ | Default: `x86_64`. Platform of coverage-reporter to use on Linux runners. Supported values: `x86_64` (default) and `aarch64` (or `arm64`). |
+| `coverage-reporter-platform` | _optional_ | Default: `auto-detect`. Platform of coverage-reporter to use on Linux runners. Supported values: `auto-detect`, `x86_64`, `aarch64`, or `arm64`. |
 
 <!-- Leaving this here until we decide whether to bring back `coveralls-api-result` in v2 -->
 <!-- Please submit any questions, suggestions, requests to: support@coveralls.io -->

--- a/action.yml
+++ b/action.yml
@@ -74,9 +74,9 @@ inputs:
     required: false
     default: 'latest'
   coverage-reporter-platform:
-    description: "Platform of coverage-reporter to use on Linux runners. Supported values: x86_64 (default) and aarch64 (or arm64)"
+    description: "Platform of coverage-reporter to use on Linux runners. Supported values: auto-detect (default), x86_64, aarch64, arm64."
     required: false
-    default: 'x86_64'
+    default: 'auto-detect'
 branding:
   color: 'green'
   icon: 'percent'
@@ -148,7 +148,9 @@ runs:
         # This logic is necessary due to the introduction of multiple platform support starting from v0.6.15.
         # It selects the correct filename based on the specified platform and version, while ensuring
         # backward compatibility with earlier versions that only supported a generic Linux binary for x86_64.
-        [ "$COVERAGE_REPORTER_PLATFORM" ] || COVERAGE_REPORTER_PLATFORM="$(uname -m)"
+        if [ -z "$COVERAGE_REPORTER_PLATFORM" ] || [ "$COVERAGE_REPORTER_PLATFORM" == "auto-detect" ]; then
+          COVERAGE_REPORTER_PLATFORM="$(uname -m)"
+        fi
         case "$COVERAGE_REPORTER_PLATFORM" in
           x86_64|"")
             if version_ge "$COVERAGE_REPORTER_VERSION" "v0.6.15"; then


### PR DESCRIPTION
This is a follow-up to #238, where I introduced a feature to automatically detect the platform when none was specified. I failed to notice that there was a default value for the variable of "x86_64" set, which effectively made the code added in #238 useless. In this pull request, I'm setting the default value to `auto-detect` so that we can get the correct platform every time.