### PR TITLE
Fix macOS install for Homebrew 6.0.0 tap trust requirement

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -102,8 +102,10 @@ runs:
         # Enable debugging if 'debug' is true
         [ "${{ inputs.debug }}" == "true" ] && set -x
 
-        # Try to install coverage-reporter via Homebrew
-        if ! brew tap coverallsapp/coveralls --quiet || ! brew install coveralls --quiet; then
+        # Try to install coverage-reporter via Homebrew.
+        # The fully-qualified formula name auto-taps the repo and trusts only
+        # this formula, as required by tap trust in Homebrew 6.0.0+.
+        if ! brew install coverallsapp/coveralls/coveralls --quiet; then
           echo "Failed to install coveralls via Homebrew (macOS)."
           [ "${{ inputs.fail-on-error }}" == "false" ] && exit 0
           exit 1


### PR DESCRIPTION
## Problem

Homebrew 6.0.0 (released 2026-06-11) requires third-party taps to be explicitly trusted before their formulae are loaded ([announcement](https://brew.sh/2026/06/11/homebrew-6.0.0/), [Tap Trust docs](https://docs.brew.sh/Tap-Trust)). The macOS install step previously ran:

```bash
brew tap coverallsapp/coveralls --quiet
brew install coveralls --quiet
```

which now fails on updated runners with:

```
Error: Refusing to load formula coverallsapp/coveralls/coveralls from untrusted tap coverallsapp/coveralls.
```

Fixes #264

## Fix

Install via the fully-qualified formula name instead:

```bash
brew install coverallsapp/coveralls/coveralls --quiet
```

A fully-qualified install auto-taps the repo and trusts only this formula, non-interactively — no separate `brew tap` needed. This is the approach recommended by the [Tap Trust docs](https://docs.brew.sh/Tap-Trust) and the same fix ddev applied for the same break (ddev/ddev#8455).

## Why not `brew trust`?

`brew trust coverallsapp/coveralls` also works, but the command doesn't exist on Homebrew < 6, so it would break runners that haven't updated yet. The fully-qualified install works on both old and new Homebrew.

## Workaround for users pinned to older action versions

```yaml
- name: Trust Coveralls Homebrew tap (Homebrew 6 requirement)
  if: runner.os == 'macOS'
  run: brew trust coverallsapp/coveralls
- uses: coverallsapp/github-action@v2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)