### PR TITLE
Add cross-platform smoke test for the published action

### DIFF
--- a/.github/workflows/smoke-test-v2.yml
+++ b/.github/workflows/smoke-test-v2.yml
@@ -1,6 +1,9 @@
 name: Smoke Test v2 (macOS end-user chain)
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  push:
+    branches: [smoke-test-v2]
 
 jobs:
   smoke:

--- a/.github/workflows/smoke-test-v2.yml
+++ b/.github/workflows/smoke-test-v2.yml
@@ -1,0 +1,38 @@
+name: Smoke Test v2 (macOS end-user chain)
+
+on: workflow_dispatch
+
+jobs:
+  smoke:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, macos-15]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create minimal lcov coverage fixture
+        run: |
+          mkdir -p coverage
+          {
+            echo "SF:action.yml"
+            echo "DA:1,1"
+            echo "DA:2,1"
+            echo "DA:3,0"
+            echo "end_of_record"
+          } > coverage/lcov.info
+
+      - name: Run published action as an end user would (issue 264 scenario)
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: coverage/lcov.info
+          fail-on-error: true
+          debug: true
+
+      - name: Verify installed coverage-reporter binary
+        run: |
+          which coveralls
+          coveralls --version

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -3,16 +3,25 @@ name: Smoke Test (published action)
 # Verifies the full end-user chain of the *published* v2 tag on every
 # supported platform: action resolution -> reporter install (Homebrew on
 # macOS, GitHub-release download on Linux/Windows) -> report upload.
-# Run it from the Actions tab after a release, a Homebrew major, or a
-# runner-image update.
+# Runs automatically after each release (once the v2 tag has been moved
+# by the Update Major Version Tag workflow).
+#
+# Run it manually after any change worth sanity-checking against the
+# published action -- e.g. a Homebrew major version, a runner-image
+# update, or an action update -- either way:
+#   - GitHub UI: Actions tab -> "Smoke Test (published action)" ->
+#     "Run workflow" -> keep branch "main" -> green "Run workflow" button
+#   - CLI: gh workflow run smoke-test.yml --repo coverallsapp/github-action
 
 on:
   workflow_dispatch:
-  push:
-    branches: [smoke-test-v2]  # temporary, for pre-merge validation; removed before merge
+  workflow_run:
+    workflows: ["Update Major Version Tag"]
+    types: [completed]
 
 jobs:
   smoke:
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,9 +1,15 @@
-name: Smoke Test v2 (macOS end-user chain)
+name: Smoke Test (published action)
+
+# Verifies the full end-user chain of the *published* v2 tag on every
+# supported platform: action resolution -> reporter install (Homebrew on
+# macOS, GitHub-release download on Linux/Windows) -> report upload.
+# Run it from the Actions tab after a release, a Homebrew major, or a
+# runner-image update.
 
 on:
   workflow_dispatch:
   push:
-    branches: [smoke-test-v2]
+    branches: [smoke-test-v2]  # temporary, for pre-merge validation; removed before merge
 
 jobs:
   smoke:
@@ -11,12 +17,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, macos-15]
+        os: [ubuntu-latest, macos-latest, macos-15, windows-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Create minimal lcov coverage fixture
+        shell: bash
         run: |
           mkdir -p coverage
           {
@@ -27,7 +34,7 @@ jobs:
             echo "end_of_record"
           } > coverage/lcov.info
 
-      - name: Run published action as an end user would (issue 264 scenario)
+      - name: Run published action as an end user would
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -36,6 +43,7 @@ jobs:
           debug: true
 
       - name: Verify installed coverage-reporter binary
+        shell: bash
         run: |
           which coveralls
           coveralls --version


### PR DESCRIPTION
Adds `.github/workflows/smoke-test.yml`, which verifies the full end-user chain of the **published** `@v2` tag — action resolution → reporter install (Homebrew tap on macOS, GitHub-release binary download on Linux/Windows) → real report upload with `fail-on-error: true` and no error masking — on `ubuntu-latest`, `windows-latest`, `macos-latest`, and `macos-15`.

This covers the gap that let #264 go unnoticed: `test.yml` exercises the local checkout (`uses: ./`) with `continue-on-error: true`, so it can neither see the published tag nor turn red when the install path breaks.

Triggers:
- **Automatically after each release**, chained to the completion of the `Update Major Version Tag` workflow (so the `v2` tag has already moved).
- **Manually** from the Actions tab or `gh workflow run smoke-test.yml` — instructions are in the workflow's comments.

Validated on this branch: all four platforms green against published v2.3.8 ([run](https://github.com/coverallsapp/github-action/actions/runs/30305923743)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)