### PR TITLE
Fix demo image link spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The "Coveralls Finished" step needs to run after all other steps have completed;
 
 ## Demo
 
-![demo](https://s3.amazonaws.com/assets.coveralls.io/Coveralls%20GitHub%20Action%20Demo%20-%20trimmed%20-%204.8x720.gif)
+![demo](https://s3.amazonaws.com/assets.coveralls.io/Coveralls%20Github%20Action%20Demo%20-%20trimmed%20-%204.8x720.gif)
 
 ### Steps shown:
 


### PR DESCRIPTION
Updated demo image link to "correct" _incorrect_ GitHub spelling (lowercase `h`).